### PR TITLE
fix: latest version in config should not be translated

### DIFF
--- a/src/ui/windows/preferences.rs
+++ b/src/ui/windows/preferences.rs
@@ -499,7 +499,7 @@ impl SimpleAsyncComponent for PreferencesApp {
         match msg {
             PreferencesAppMsg::SelectWineVersion(index) => {
                 let version = if index == 0 {
-                    tr!("components-wine-latest")
+                    "latest".to_owned()
                 } else {
                     self.wine_versions[index as usize - 1].name.clone()
                 };
@@ -514,7 +514,7 @@ impl SimpleAsyncComponent for PreferencesApp {
 
             PreferencesAppMsg::SelectDxvkVersion(index) => {
                 let version = if index == 0 {
-                    tr!("components-dxvk-latest")
+                    "latest".to_owned()
                 } else {
                     self.dxvk_versions[index as usize - 1].version.clone()
                 };


### PR DESCRIPTION
Problem: (same as #14)
1. change wine/dxvk version to any other version
2. change wine/dxvk version back to latest
3. reopen launcher will show error dialog "No appropriate wine version found"

Solve:
version string in config file should be "latest", not tr!("latest")