### PR TITLE
Added devtool to serve file of a directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ name = "anime-games-launcher"
 version = "2.0.0-alpha1"
 dependencies = [
  "anyhow",
+ "axum",
  "base32",
  "base64",
  "bufreaderwriter",
@@ -59,6 +60,7 @@ dependencies = [
  "gtk4",
  "hex",
  "human-panic",
+ "infer",
  "lazy_static",
  "libadwaita",
  "md-5",
@@ -169,6 +171,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "axum"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +351,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "shlex",
+]
+
+[[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
 ]
 
 [[package]]
@@ -1129,6 +1202,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "human-panic"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1236,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1369,6 +1449,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
 name = "intl-memoizer"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1618,12 @@ checksum = "76ae337c644bbf86a8d8e9ce3ee023311833d41741baf5e51acc31b37843aba1"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -2270,6 +2365,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,6 +2772,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2687,6 +2793,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "base32",
  "base64",
  "bufreaderwriter",
+ "clap",
  "crc32c",
  "crc32fast",
  "encoding_rs",
@@ -311,6 +312,46 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.5.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -2360,6 +2401,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,4 +95,7 @@ human-panic = "2.0"
 
 fluent-templates = "0.11"
 unic-langid = "0.9"
+
 clap = { version = "4.5.36", features = ["derive"] }
+axum = "0.8.3"
+infer = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,4 @@ human-panic = "2.0"
 
 fluent-templates = "0.11"
 unic-langid = "0.9"
+clap = { version = "4.5.36", features = ["derive"] }

--- a/src/cli/argument.rs
+++ b/src/cli/argument.rs
@@ -1,0 +1,18 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    ///Serve a directory where a registry is located
+    Serve {
+        ///The directory which will be served 
+        #[arg(long, default_value_t = String::from("."))]
+        dir_to_serve: String,
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,1 @@
+pub mod argument;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,1 +1,2 @@
 pub mod argument;
+pub mod serve;

--- a/src/cli/serve/config.rs
+++ b/src/cli/serve/config.rs
@@ -3,19 +3,12 @@ use serde::{Deserialize, Serialize};
 pub static CONFIG_FILE_NAME: &str = "serve.toml";
 
 #[derive(Deserialize, Serialize)]
+#[derive(Default)]
 pub struct Config {
     pub serve_at: ServeAt,
     pub mislead: Mislead,
 }
 
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            serve_at: ServeAt::default(),
-            mislead: Mislead::default(),
-        }
-    }
-}
 
 #[derive(Deserialize, Serialize)]
 pub struct ServeAt {

--- a/src/cli/serve/config.rs
+++ b/src/cli/serve/config.rs
@@ -1,0 +1,48 @@
+use serde::{Deserialize, Serialize};
+
+pub static CONFIG_FILE_NAME: &str = "serve.toml";
+
+#[derive(Deserialize, Serialize)]
+pub struct Config {
+    pub serve_at: ServeAt,
+    pub mislead: Mislead,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            serve_at: ServeAt::default(),
+            mislead: Mislead::default(),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct ServeAt {
+    pub ip: String,
+    pub port: u16,
+}
+
+impl Default for ServeAt {
+    fn default() -> Self {
+        ServeAt {
+            ip: String::from("127.0.0.1"),
+            port: 8080,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+pub struct Mislead {
+    pub link_to_mislead: String,
+    pub mislead_to: String,
+}
+
+impl Default for Mislead {
+    fn default() -> Self {
+        Mislead {
+            link_to_mislead: String::from("http://127.0.0.1:8080"),
+            mislead_to: String::from("http://127.0.0.1:8080"),
+        }
+    }
+}

--- a/src/cli/serve/mod.rs
+++ b/src/cli/serve/mod.rs
@@ -1,0 +1,111 @@
+use std::path::{Path, PathBuf};
+
+use axum::{body::Body, http::{Request, Response, StatusCode}, response::IntoResponse, routing::get, Router};
+
+mod config;
+
+pub async fn run(dir_to_serve: String) -> anyhow::Result<()> {
+    let current_path = PathBuf::from(dir_to_serve);
+    let config_file_path = current_path.join(config::CONFIG_FILE_NAME);
+
+    let config: config::Config = match tokio::fs::read_to_string(config_file_path).await {
+        Ok(content) => match toml::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::error!(
+                    "Failed to read config file, using default one, please check your config : {}",
+                    e
+                );
+                config::Config::default()
+            }
+        },
+        Err(_) => {
+            tracing::warn!(
+                "Seems that your config file is missing, creating default configuration for you...."
+            );
+            let config = config::Config::default();
+            let config_path = current_path.join(config::CONFIG_FILE_NAME);
+            let new_config_file_content = toml::to_string(&config)?;
+
+            tokio::fs::write(config_path, new_config_file_content.as_bytes()).await?;
+
+            config
+        }
+    };
+
+    let ip = config.serve_at.ip.parse::<std::net::Ipv4Addr>()?;
+    let port = config.serve_at.port;
+
+    let addr = std::net::SocketAddr::from((ip, port));
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+
+    let dir_to_serve = current_path.clone();
+    let router = Router::new().fallback_service(get(move |req: Request<Body>| {
+        serve_dir(req, dir_to_serve, config.mislead)
+    }));
+
+    tracing::info!("listening on \t-> {}", listener.local_addr()?);
+    tracing::info!("serving dir \t-> {}", current_path.to_str().unwrap());
+    axum::serve(listener, router).await?;
+
+    Ok(())
+}
+
+async fn serve_dir(
+    request: Request<Body>,
+    base_dir: PathBuf,
+    mislead: config::Mislead,
+) -> impl IntoResponse {
+    let uri_path = request.uri().path().trim_start_matches("/");
+    let file_path = base_dir.join(uri_path);
+
+    if !file_path.exists() || file_path.is_dir() {
+        return (StatusCode::NOT_FOUND, "File not found").into_response();
+    }
+
+    tracing::info!("Serving \t-> {}", file_path.to_str().unwrap());
+
+    if let Some(mime_type) = is_image_file(file_path.clone()).await.unwrap_or(None) {
+        match tokio::fs::read(file_path).await {
+            Ok(content) => Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", mime_type)
+                .body(Body::from(content))
+                .unwrap(),
+            Err(err) => {
+                tracing::error!("Failed to read file : {}", err);
+                (StatusCode::INTERNAL_SERVER_ERROR, "Error reading file").into_response()
+            }
+        }
+    } else {
+        match tokio::fs::read_to_string(file_path).await {
+            Ok(content) => {
+                let edited_content = content.replace(&mislead.link_to_mislead, &mislead.mislead_to);
+
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header("Content-type", "application/octet-stream")
+                    .body(Body::from(edited_content))
+                    .unwrap()
+            }
+            Err(err) => {
+                tracing::error!("Failed to read file : {}", err);
+                (StatusCode::INTERNAL_SERVER_ERROR, "Error reading file").into_response()
+            }
+        }
+    }
+}
+
+async fn is_image_file(path: impl AsRef<Path>) -> anyhow::Result<Option<String>> {
+    let kind = infer::get_from_path(path)?;
+
+    if let Some(file) = kind {
+        if file.mime_type().starts_with("image") {
+            Ok(Some(String::from(file.mime_type())))
+        } else {
+            Ok(None)
+        }
+    } else {
+        Ok(None)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,12 +105,12 @@ async fn main() -> anyhow::Result<()> {
     let args = cli::argument::Args::parse();
 
     if args.command.is_some() {
-        match args.command.unwrap() {
+        return match args.command.unwrap() {
             cli::argument::Commands::Serve { dir_to_serve } => {
                 tracing::info!("Start serving!");
+                cli::serve::run(dir_to_serve).await
             },
-        }
-        return Ok(());
+        };
     }
 
     tracing::info!("Starting application ({APP_VERSION})");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 
+use clap::Parser;
 use relm4::prelude::*;
 
 use tracing_subscriber::prelude::*;
@@ -9,6 +10,7 @@ pub mod consts;
 pub mod core;
 pub mod config;
 pub mod cache;
+pub mod cli;
 pub mod packages;
 pub mod generations;
 pub mod games;
@@ -98,6 +100,18 @@ async fn main() -> anyhow::Result<()> {
         .with(debug_log)
         .with(trace_log)
         .init();
+
+    // Parse arguments
+    let args = cli::argument::Args::parse();
+
+    if args.command.is_some() {
+        match args.command.unwrap() {
+            cli::argument::Commands::Serve { dir_to_serve } => {
+                tracing::info!("Start serving!");
+            },
+        }
+        return Ok(());
+    }
 
     tracing::info!("Starting application ({APP_VERSION})");
 


### PR DESCRIPTION
I integrated the code from [this repo](https://github.com/ALEZ-DEV/Bread-Scripter) to this codebase to simplify the developement of game integrations scripts

what this PR add to the launcher :
- `cli` folder at `src/cli` which add all the cli related things
- the command `anime-game-launcher serve` which will start to serve a directory
  you can add the argument `--dir-to-serve` to indicate the dir to serve, by default it's the current dir

when serving, the launcher will hot patch the game integrations repo link to the local link (`http://127.0.0.1:8080`).
This can be edited in the config file which is automatically created if not existing at the directory which the launcher is serving at. the config file is called `serve.toml`