### PR TITLE
ci: cache apt packages in container builds

### DIFF
--- a/.github/workflows/check_source_code.yml
+++ b/.github/workflows/check_source_code.yml
@@ -33,6 +33,21 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
 
     steps:
+      - name: Configure apt to keep downloaded packages
+        run: |
+          rm -f /etc/apt/apt.conf.d/docker-clean
+          echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+      - name: Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            /var/cache/apt/archives
+            /var/lib/apt/lists
+          key: apt-ubuntu-devel-check-${{ hashFiles('.github/workflows/check_source_code.yml') }}
+          restore-keys: |
+            apt-ubuntu-devel-check-
+
       - name: Install build dependencies
         run: |
           apt update
@@ -40,7 +55,6 @@ jobs:
 
       - name: Install runtime dependencies
         run: |
-          apt update
           apt install -y tar zip p7zip-full gzip bzip2 zstd
 
       - name: Download rust toolchain

--- a/.github/workflows/compile_release_build.yml
+++ b/.github/workflows/compile_release_build.yml
@@ -28,6 +28,21 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
 
     steps:
+      - name: Configure apt to keep downloaded packages
+        run: |
+          rm -f /etc/apt/apt.conf.d/docker-clean
+          echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+      - name: Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            /var/cache/apt/archives
+            /var/lib/apt/lists
+          key: apt-ubuntu-devel-release-${{ hashFiles('.github/workflows/compile_release_build.yml') }}
+          restore-keys: |
+            apt-ubuntu-devel-release-
+
       - name: Install build dependencies
         run: |
           apt update


### PR DESCRIPTION
The `check_source_code` and `compile_release_build` jobs run inside a fresh `ubuntu:devel` container and `apt install` the GTK4 / libadwaita devel chain plus `build-essential`. That pulls in roughly 410 transitive packages and several hundred MB on every run, which is what's eating the 2-3 minutes you saw on job 74077451496.

How it works:

- Removes `/etc/apt/apt.conf.d/docker-clean` and sets `Binary::apt::APT::Keep-Downloaded-Packages "true"` so apt actually retains downloaded `.deb` files inside the container.
- Adds an `actions/cache@v4` step that caches `/var/cache/apt/archives` and `/var/lib/apt/lists`, keyed on the workflow file's hash with a prefix `restore-keys` fallback. On a cache hit, the existing `apt install` calls reuse local `.debs` instead of re-downloading them. Blacksmith's colocated cache makes the restore itself fast.
- Drops the duplicate `apt update` from the runtime-deps step in `check_source_code.yml`; the build-deps step right above already updated the lists.

The cache key includes the workflow file hash, so changing the package list invalidates the cache automatically. `apt update` still runs each time, so any newer `.deb` versions are picked up normally; this only short-circuits the download when versions match. No behavior change to what gets installed.

If you want to push this further, the next step would be a pre-baked `ghcr.io` image with these deps already installed (built via `useblacksmith/setup-docker-builder` + `useblacksmith/build-push-action` for layer caching), referenced from `container:`. Happy to follow up with that if this isn't enough.