### PR TITLE
Release v2.1.1

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: an-anime-team
+open_collective: dawn-winery

--- a/.github/workflows/compile_release_build.yml
+++ b/.github/workflows/compile_release_build.yml
@@ -2,15 +2,8 @@ name: Compile release build
 
 on:
   push:
-    branches:
-      - master
-
-    paths:
-      - "crates/*/src/**"
-
-  release:
-    types:
-      - published
+    tags:
+      - 'v*'
 
   workflow_dispatch:
 
@@ -42,7 +35,7 @@ jobs:
           key: apt-ubuntu-devel-release-${{ hashFiles('.github/workflows/compile_release_build.yml') }}
           restore-keys: |
             apt-ubuntu-devel-release-
-            
+
       - name: Install build dependencies
         run: |
           apt update

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 /perf.data.old
 /perf-output.data
 /profile.json
+
+# Ignore all markdowns except readme and changelog
+/*.md
+!/README.md
+!/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Games API got new values format for `enum` and `selector` settings entries.
+- Added `accessed_at` field to the `fs.metadata` runtime API.
+- Added `import` function to the runtime API.
+- Added Japanese and Portuguese translations.
+- Cache, resources, modules, and temporary directories got garbage collection
+  mechanism in the launcher controlled by related config file settings. Now
+  launcher will automatically scan these directories at startup and delete old
+  (unused) files / directories.
+- Launcher now will set parent game binary's directory as the spawned game
+  process's current working directory.
+- Added `locales.py` script to work with launcher localizations.
+
+### Changed
+
+- All network connections now respect system proxy settings. Used proxy address
+  can be overridden in the launcher's config file.
+- `fs.metadata` runtime API will set `created_at`, `modified_at` and
+  `accessed_at` as `nil` instead of returning an error if user file system
+  doesn't support these fields.
+- Many internal IO operations were made async.
+- `general.network.proxy.url` and `general.network.proxy.mode` launcher settings
+  were replaced by `general.network.proxy` string. Previous
+  `general.network.proxy.url` value will be moved to the new
+  `general.network.proxy` field.
+- Network requests user agent string was changed to
+  `anime-games-launcher/v<version>` in the launcher, and to `anirun/v<version>`
+  in the anirun CLI. Previously application version didn't have `v` letter
+  prefix in the user agent string.
+- Some environment variables were renamed:
+  `LAUNCHER_DATA_FOLDER` -> `LAUNCHER_DATA_DIR`;
+  `LAUNCHER_CONFIG_FOLDER` -> `LAUNCHER_CONFIG_DIR`;
+  `LAUNCHER_CACHE_FOLDER` -> `LAUNCHER_CACHE_DIR`.
+
 ## [v2.1.0] - 16.05.2026
 
 ### Added
 
-- Added Italian translations
-- Added game integration agreements
+- Added Italian translations.
+- Added game integration agreements.
 - When launched in debug mode (`--agl-debug` flag) the launcher will show
-  entries names for settings and components as hints
-- Added new settings entry format for secrets (e.g. passwords)
+  entries names for settings and components as hints.
+- Added new settings entry format for secrets (e.g. passwords).
 - Added optional game components system which required a big rewrite of the
-  launcher's backend code
-- Added Protobuf API to the lua runtime
+  launcher's backend code.
+- Added Protobuf API to the lua runtime.
 
 ### Fixed
 
-- Selectable strings are not highlighted, focused or selected by default anymore
-- Game variants are now properly selected and propagated to the lua side
-- Actions in the actions pipeline window now properly render their descriptions
+- Selectable strings are not highlighted, focused or selected by default
+  anymore.
+- Game variants are now properly selected and propagated to the lua side.
+- Actions in the actions pipeline window now properly render their descriptions.
 - Fixed a bug when the game library details window was updated 3 times instead
-  of 1
+  of 1.
 - Fixed automatic game selection on the library page if "open in library" button
-  on the game store page was clicked
-- Fixed system language identification
+  on the game store page was clicked.
+- Fixed system language identification.
 
 ### Changed
 
@@ -39,168 +75,168 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Strings translations engine now respects regional language variants
-- Added Indonesian launcher translations
+- Strings translations engine now respects regional language variants.
+- Added Indonesian launcher translations.
 - Added `--agl-debug` launcher launch flag to display trace logs in release
-  builds
+  builds.
 - Added spinner widget to the actions pipeline window if the current action has
-  no progress and no text
+  no progress and no text.
 
 ### Fixed
 
-- Fixed `process.exec`'s `Promise` awaiting
-- Fixed rendering of long game titles
-- Fixed empty pipeline action description setting
+- Fixed `process.exec`'s `Promise` awaiting.
+- Fixed rendering of long game titles.
+- Fixed empty pipeline action description setting.
 
 ### Changed
 
 - Improved actions pipeline chart rendering. Now it uses 5-step WMA over the
-  points history
+  points history.
 
 ### Removed
 
 - Removed automatic luau engine garbage collection from the launcher's side.
-  It was causing a UI thread blocks
+  It was causing a UI thread blocks.
 
 ## [v2.0.0-rc1] - 19.03.2026
 
 ### Added
 
-- Added `anirun` binary to test luau runtime packages and modules
-- Added BSON format support in `string.encode`, `string.decode` runtime APIs
+- Added `anirun` binary to test luau runtime packages and modules.
+- Added BSON format support in `string.encode`, `string.decode` runtime APIs.
 - Added support for functions without output (without `return` statements) in
-  `Promise.poll` runtime API
+  `Promise.poll` runtime API.
 - Added custom user agent in all the HTTP requests, including downloader runtime
   API: `User-Agent: anime-games-launcher/<version>`. The HTTP runtime API can
   overwrite this value, but downloader API cannot. All the launcher's own
-  requests will use this custom user agent too
+  requests will use this custom user agent too.
 - Added standard luau `number` table to support advanced arithmetic functions
   in the luau runtime. Global environment table building was slightly optimized
-  too
+  too.
 - Added `stringify` runtime API to convert lua objects to strings and return
-  them back to the lua runtime side
-- Added "No games available" status in store page
+  them back to the lua runtime side.
+- Added "No games available" status in store page.
 - Added `str.lowercase`, `str.uppercase` and `str.trim` runtime APIs to support
-  unicode characters (standard lua functions work only with ASCII)
-- Added `selector` and `number` game settings entry formats
+  unicode characters (standard lua functions work only with ASCII).
+- Added `selector` and `number` game settings entry formats.
 - Added search bar to `enum` game settings entry if there's 10 or more values
-  available
+  available.
 - Added `tools.get_buttons` game integration function. Now integrations can add
   their own buttons to the library details page for different needs, e.g.
   "Delete game files", or "Open wine config". Clicking on these buttons will
-  reload game info after the button's callback is executed
+  reload game info after the button's callback is executed.
 - Added launcher-side luau runtime garbage collection task, and related
   `runtime.collect_garbage_interval` config. While luau engine itself should
   perform garbage collection automatically, launcher will perform full
   collection cycles from time to time. This can be disabled by settings this
-  config to `0`
+  config to `0`.
 
 ### Fixed
 
-- Fixed `hash.digitize_file` runtime API stack overflow
-- Fixed `POST` method name in HTTP runtime API
-- Fixed game scope overwriting with default values in added games' manifests
+- Fixed `hash.digitize_file` runtime API stack overflow.
+- Fixed `POST` method name in HTTP runtime API.
+- Fixed game scope overwriting with default values in added games' manifests.
 - Fixed default image rendering in horizontal lazy loadable pictures. Previously
   only vertical pictures (cards) had proper default image scaling and
-  positioning
-- Fixed tests and CI workflows
+  positioning.
+- Fixed tests and CI workflows.
 
 ### Changed
 
-- Disable human panic in debug builds
-- Return `nil` in `compression.read` runtime API if nothing to read
+- Disable human panic in debug builds.
+- Return `nil` in `compression.read` runtime API if nothing to read.
 - Changed `string.encode` and `string.decode` runtime API args order. Now
-  in all the similar APIs the algorithm name goes first, arguments go next
+  in all the similar APIs the algorithm name goes first, arguments go next.
 - In game details within the store page, carousel will now hide controls if
-  there's only one picture available
-- Featured games are now shown before non-featured games
+  there's only one picture available.
+- Featured games are now shown before non-featured games.
 
 ## [v2.0.0-beta4] - 03.01.2026
 
 ### Added
 
-- `torrent.add` API got `restart` option to restart already added torrents
+- `torrent.add` API got `restart` option to restart already added torrents.
 - Added launcher localization using in-house `agl-locale` crate;
-  English, Russian, German and Portuguese languages are supported now
-- Game integrations now can be returned by a function to support lazy loading
+  English, Russian, German and Portuguese languages are supported now.
+- Game integrations now can be returned by a function to support lazy loading.
 - Added task API with `Promise` userdata type. If returned from runtime - the
-  actual work happens in background and doesn't block lua engine thread
+  actual work happens in background and doesn't block lua engine thread.
 - Added `await` runtime function to resolve different lua types, including
-  functions, coroutines (threads), `Promises` and more
+  functions, coroutines (threads), `Promises` and more.
 - Added `Bytes` userdata type to replace tables of numbers used to represent
   bytes on lua side. Most of runtime API methods were reworked to return and
-  accept this custom type
+  accept this custom type.
 - Added system API to query system-related information, currently local and UTC
-  time, environment variables and binaries paths
+  time, environment variables and binaries paths.
 
 ### Fixed
 
-- Actions pipeline execution graph now resets on window close
-- Fixed vertical distance between store page game cards
-- Fixed `http.fetch` options parsing
+- Actions pipeline execution graph now resets on window close.
+- Fixed vertical distance between store page game cards.
+- Fixed `http.fetch` options parsing.
 - Process API now doesn't resolve the binary path and doesn't check for relative
-  path
+  path.
 
 ### Changed
 
-- Force torrent API to add global torrents list to each added torrent
-- Display progress bar in actions pipeline window even if current progress is 0
-- Updated lua engine version; 64 bit numbers should be supported now
-- Changed required GTK4 and libadwaita versions to support older linux distros
-- Add more environment variables to parse system language from
-- Renamed network API to HTTP API
+- Force torrent API to add global torrents list to each added torrent.
+- Display progress bar in actions pipeline window even if current progress is 0.
+- Updated lua engine version; 64 bit numbers should be supported now.
+- Changed required GTK4 and libadwaita versions to support older linux distros.
+- Add more environment variables to parse system language from.
+- Renamed network API to HTTP API.
 - Most of runtime API methods were promisified (reworked to return `Promise`)
-  and perform actual work in background to not to block lua engine thread
-- In-RAM memory buffers for some APIs were increased for better performance
+  and perform actual work in background to not to block lua engine thread.
+- In-RAM memory buffers for some APIs were increased for better performance.
 - Sqlite API now can accept functions, coroutines (threads), `Promise` and
-  `Bytes` types as query params (they will be resolved into actual values)
+  `Bytes` types as query params (they will be resolved into actual values).
 
 ### Removed
 
-- Removed unused `utils` and `i18n` launcher modules
+- Removed unused `utils` and `i18n` launcher modules.
 
 ## [v2.0.0-beta3] - 24.12.2025
 
 ### Added
 
-- Added special handling for empty game editions list
-- Added runtime torrent API
-- Added `sleep` runtime function
+- Added special handling for empty game editions list.
+- Added runtime torrent API.
+- Added `sleep` runtime function.
 
 ### Changed
 
-- Improve actions pipeline graph drawing
+- Improve actions pipeline graph drawing.
 
 ## [v2.0.0-beta2] - 22.12.2025
 
 ### Added
 
 - Added separate read and write permissions to sandboxed filesystem paths in
-  modules runtime
+  modules runtime.
 - Added modules allow lists. Modules runtime tries to read module's scope from
-  it and falls back to default values
+  it and falls back to default values.
 - Add module scope to the game package lock. This scope will be applied to all
   the modules used by the game integration (game-specific sandbox permissions)
-- Added portal API
-- Added logging for runtime modules loading
+- Added portal API.
+- Added logging for runtime modules loading.
 
 ### Fixed
 
-- Fixed layout of the games store details page
-- Provide most of default lua functions for runtime modules
+- Fixed layout of the games store details page.
+- Provide most of default lua functions for runtime modules.
 - Input resources of a package are now allowed to be read by output modules of
-  this package
-- Fixed panic message on application close
-- Fixed game launch info hint being `nil` when unset
+  this package.
+- Fixed panic message on application close.
+- Fixed game launch info hint being `nil` when unset.
 
 ### Changed
 
-- Changed logging filters for stdout and `debug.log` file
+- Changed logging filters for stdout and `debug.log` file.
 - Game integration pipeline actions now don't need to return any (boolean)
-  output from `perform` functions
-- Changed pipeline actions graph update rate to 0.5 seconds
+  output from `perform` functions.
+- Changed pipeline actions graph update rate to 0.5 seconds.
 - In many manifests `format` is expected instead of `version`. For now `version`
-  is accepted as fallback field
+  is accepted as fallback field.
 
 ## [v2.0.0-beta1] - 20.12.2025
 
@@ -210,32 +246,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added game description wrapping on the store page
-- Added `fs.seek_rel` and `fs.truncate` methods to the v1 packages standard
-- Added SQLite and Portals APIs for v1 packages standard
-- Automatically resolve relative paths in v1 standard's filesystem API
+- Added game description wrapping on the store page.
+- Added `fs.seek_rel` and `fs.truncate` methods to the v1 packages standard.
+- Added SQLite and Portals APIs for v1 packages standard.
+- Automatically resolve relative paths in v1 standard's filesystem API.
 
 ### Fixed
 
 - Fixed null values decoding from `json` and other formats in the `str.decode`
-  v1 packages standard
-- Fixed total download size detection in v1 standard's Downloader API
+  v1 packages standard.
+- Fixed total download size detection in v1 standard's Downloader API.
 
 ### Changed
 
-- Updated `mlua` to version ^0.10
-- Slightly optimized lua tables creation in many places
-- Disabled low-level network-related logging
-- Updated v1 standard's Downloader API to allow parallel download tasks
-- Changed path returned by the `path.persist_dir` method in the v1 packages standard
-- Updated packages loading order in the engine code
-- Made game editions optional in the v1 games integrations standard
-- Enum rows returned from the v1 games integrations standard are now forcely sorted
-- Now v1 packages engine's `clone` function preserves metatables
+- Updated `mlua` to version ^0.10.
+- Slightly optimized lua tables creation in many places.
+- Disabled low-level network-related logging.
+- Updated v1 standard's Downloader API to allow parallel download tasks.
+- Changed path returned by the `path.persist_dir` method in the v1 packages
+  standard.
+- Updated packages loading order in the engine code.
+- Made game editions optional in the v1 games integrations standard.
+- Enum rows returned from the v1 games integrations standard are now forcely
+  sorted.
+- Now v1 packages engine's `clone` function preserves metatables.
 
 ### Removed
 
-- Removed `update-unavailable` game status from the v1 games integrations standard
+- Removed `update-unavailable` game status from the v1 games integrations
+  standard.
 
 ## [v2.0.0-alpha1] - 14.04.2025
 
@@ -245,24 +284,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Fixed German
-- Replaced `v1_network_http_get` with more powerful `v1_network_fetch`
+- Fixed German.
+- Replaced `v1_network_http_get` with more powerful `v1_network_fetch`.
 
 ## [v1.0.1] - 20.01.2024
 
 ### Added
 
-- Added Chinese
-- Added Portuguese
-- Added German
-- Added outdated games category
-- Added virtual desktop preference
-- Added xxhash support
-- Added `pre_transition` optional API
+- Added Chinese.
+- Added Portuguese.
+- Added German.
+- Added outdated games category.
+- Added virtual desktop preference.
+- Added xxhash support.
+- Added `pre_transition` optional API.
 
 ### Changed
 
-- Updated `v1_network_http_get` standard
+- Updated `v1_network_http_get` standard.
 
 ## [v1.0.0] - 13.01.2024
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
  "lazy_static",
  "lz4_flex",
  "md-5",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "seahash",
  "sha1",
  "sha2",
@@ -139,9 +139,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -255,15 +255,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -276,9 +276,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "assert_cfg"
@@ -462,15 +462,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -479,14 +479,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -564,15 +565,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -614,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -645,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -656,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -697,13 +698,13 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -714,9 +715,9 @@ checksum = "394c22b416e3981206df472c3bcbbf9ae130883619aefc2199e6087517af1bba"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -726,9 +727,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bzip2"
@@ -758,7 +759,7 @@ checksum = "5cc8d9aa793480744cd9a0524fef1a2e197d9eaa0f739cde19d16aba530dcb95"
 dependencies = [
  "bitflags",
  "cairo-sys-rs",
- "glib 0.22.7",
+ "glib 0.22.8",
  "libc",
 ]
 
@@ -768,16 +769,16 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8b4985713047f5faee02b8db6a6ef32bbb50269ff53c1aee716d1d195b76d54"
 dependencies = [
- "glib-sys 0.22.6",
+ "glib-sys 0.22.8",
  "libc",
  "system-deps",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -787,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -809,9 +810,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -820,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1018,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -1061,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1086,7 +1087,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1107,9 +1107,9 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1147,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1185,9 +1185,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -1341,12 +1341,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1467,9 +1461,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -1495,8 +1489,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f420376dbee041b2db374ce4573892a36222bb3f6c0c43e24f0d67eae9b646"
 dependencies = [
  "gdk-pixbuf-sys",
- "gio 0.22.6",
- "glib 0.22.7",
+ "gio 0.22.8",
+ "glib 0.22.8",
  "libc",
 ]
 
@@ -1506,8 +1500,8 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f31b37b1fc4b48b54f6b91b7ef04c18e00b4585d98359dd7b998774bbd91fb"
 dependencies = [
- "gio-sys 0.22.0",
- "glib-sys 0.22.6",
+ "gio-sys 0.22.8",
+ "glib-sys 0.22.8",
  "gobject-sys 0.22.6",
  "libc",
  "system-deps",
@@ -1515,29 +1509,29 @@ dependencies = [
 
 [[package]]
 name = "gdk4"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd42fdbbf48612c6e8f47c65fb92d2e8f39c25aecd6af047e83897c1a22d2a4e"
+checksum = "d81e2a6c6ecba2aab60633a98df1868b03fa0bfdce8105edc27c1bccf71f0e39"
 dependencies = [
  "cairo-rs",
  "gdk-pixbuf",
  "gdk4-sys",
- "gio 0.22.6",
- "glib 0.22.7",
+ "gio 0.22.8",
+ "glib 0.22.8",
  "libc",
  "pango",
 ]
 
 [[package]]
 name = "gdk4-sys"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d974ac4f15e67472c3a9728daf612590b4a5762a4b33f0edd298df0b80d043c"
+checksum = "3d8f608d8d7d229975c4d0d026f5d3071598c4ddab3c5262b0a31840fec78d13"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
- "gio-sys 0.22.0",
- "glib-sys 0.22.6",
+ "gio-sys 0.22.8",
+ "glib-sys 0.22.8",
  "gobject-sys 0.22.6",
  "libc",
  "pango-sys",
@@ -1593,16 +1587,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1630,16 +1622,16 @@ dependencies = [
 
 [[package]]
 name = "gio"
-version = "0.22.6"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3848bcba3a35cc0a71df8ba8ecfd799d6bfb862342a53a4a915fb62213aa4e6"
+checksum = "8b3e1f669909c326b9413bde5a742097b8c90a7d78f45326db13668984769ded"
 dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
  "futures-util",
- "gio-sys 0.22.0",
- "glib 0.22.7",
+ "gio-sys 0.22.8",
+ "glib 0.22.8",
  "libc",
  "pin-project-lite",
  "smallvec",
@@ -1660,11 +1652,11 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.22.0"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64729ba2772c080448f9f966dba8f4456beeb100d8c28a865ef8a0f2ef4987e1"
+checksum = "353fdc7da7cd16da916104b1e0e4e7de380ec9c8aaa20d4d742d66310ab4b0d5"
 dependencies = [
- "glib-sys 0.22.6",
+ "glib-sys 0.22.8",
  "gobject-sys 0.22.6",
  "libc",
  "system-deps",
@@ -1694,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.22.7"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c207e04e51605dcf7b2924c41591b3a10e1438eaac5bcf448fb91f325381104a"
+checksum = "ddbcf514bd1881fc1b960e4e52b4e82873f4da3bceddbd58d42827b508888100"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -1704,9 +1696,9 @@ dependencies = [
  "futures-executor",
  "futures-task",
  "futures-util",
- "gio-sys 0.22.0",
+ "gio-sys 0.22.8",
  "glib-macros 0.22.6",
- "glib-sys 0.22.6",
+ "glib-sys 0.22.8",
  "gobject-sys 0.22.6",
  "libc",
  "memchr",
@@ -1759,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.22.6"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7fbac234ed5bc2a28359b7bde8e1b9cdf1441cc2d7f068e4824672d7db9445"
+checksum = "030967459f9f676851872c6304adea7825c6d462ec9b72554c733cf0c5952233"
 dependencies = [
  "libc",
  "system-deps",
@@ -1784,7 +1776,7 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a861859b887a79cf461359c192c97a57d8fb0229dd291232e57aa11f6fa72c"
 dependencies = [
- "glib-sys 0.22.6",
+ "glib-sys 0.22.8",
  "libc",
  "system-deps",
 ]
@@ -1814,36 +1806,34 @@ dependencies = [
 
 [[package]]
 name = "graphene-rs"
-version = "0.22.0"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d1b7881f96869f49808b6adfe906a93a57a34204952253444d68c3208d71f1"
+checksum = "eb856b9c558971c3f13ab692358926da710b046932a4e087aedcc35b040d7dff"
 dependencies = [
- "glib 0.22.7",
+ "glib 0.22.8",
  "graphene-sys",
- "libc",
 ]
 
 [[package]]
 name = "graphene-sys"
-version = "0.22.0"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517f062f3fd6b7fd3e57a3f038a74b3c23ca32f51199ff028aa704609943f79c"
+checksum = "5c7ffdfde88f3570d3705e0d8a2433e036d387a1f2930bbf47eafcb5f569fd04"
 dependencies = [
- "glib-sys 0.22.6",
+ "glib-sys 0.22.8",
  "libc",
- "pkg-config",
  "system-deps",
 ]
 
 [[package]]
 name = "gsk4"
-version = "0.11.1"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c912dfcbd28acace5fc99c40bb9f25e1dcb73efb1f2608327f66a99acdcb62"
+checksum = "b867be1c5f14dcb8f552c0eff6e9a9b1da5f8b43943e8efc3a63c889d84952ff"
 dependencies = [
  "cairo-rs",
  "gdk4",
- "glib 0.22.7",
+ "glib 0.22.8",
  "graphene-rs",
  "gsk4-sys",
  "libc",
@@ -1852,13 +1842,13 @@ dependencies = [
 
 [[package]]
 name = "gsk4-sys"
-version = "0.11.1"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d54bbc7a9d8b6ffe4f0c95eede15ccfb365c8bf521275abe6bcfb57b18fb8a"
+checksum = "5b7c7eb2e681ee896646cfb8872b431f24d09f53ba9283289d9b10caa6707088"
 dependencies = [
  "cairo-sys-rs",
  "gdk4-sys",
- "glib-sys 0.22.6",
+ "glib-sys 0.22.8",
  "gobject-sys 0.22.6",
  "graphene-sys",
  "libc",
@@ -1868,17 +1858,17 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7181b837f04cbe93f79441475f7a00560a92cba7a72e38cc1a68b6f8b78eaae2"
+checksum = "98a0a0466484f64b07b5b8184d43fa46be78eb0b8e04ae4e179af31d770b76d9"
 dependencies = [
  "cairo-rs",
  "field-offset",
  "futures-channel",
  "gdk-pixbuf",
  "gdk4",
- "gio 0.22.6",
- "glib 0.22.7",
+ "gio 0.22.8",
+ "glib 0.22.8",
  "graphene-rs",
  "gsk4",
  "gtk4-macros",
@@ -1889,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-macros"
-version = "0.11.0"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3581b242ba62fdff122ebb626ea641582ec326031622bd19d60f85029c804a87"
+checksum = "5ac7179400a36a04de039c24206bb841c5596992b907b43b23ee8d5bdc40d00e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1901,15 +1891,15 @@ dependencies = [
 
 [[package]]
 name = "gtk4-sys"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ba8e695e2640455561274e65e45f0a151619e450746007667f4b23ceae4e1b"
+checksum = "82b8f954786af0b1984425c4446b77f5ff6594346181316be3f850caab1c6f01"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
  "gdk4-sys",
- "gio-sys 0.22.0",
- "glib-sys 0.22.6",
+ "gio-sys 0.22.8",
+ "glib-sys 0.22.8",
  "gobject-sys 0.22.6",
  "graphene-sys",
  "gsk4-sys",
@@ -1920,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1951,22 +1941,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1977,9 +1958,9 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2004,9 +1985,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2059,18 +2040,18 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2235,12 +2216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,13 +2371,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2434,20 +2408,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libadwaita"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0da4e27b20d3e71f830e5b0f0188d22c257986bf421c02cfde777fe07932a4"
 dependencies = [
  "gdk4",
- "gio 0.22.6",
- "glib 0.22.7",
+ "gio 0.22.8",
+ "glib 0.22.8",
  "gtk4",
  "libadwaita-sys",
  "libc",
@@ -2461,8 +2429,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaee067051c5d3c058d050d167688b80b67de1950cfca77730549aa761fc5d7d"
 dependencies = [
  "gdk4-sys",
- "gio-sys 0.22.0",
- "glib-sys 0.22.6",
+ "gio-sys 0.22.8",
+ "glib-sys 0.22.8",
  "gobject-sys 0.22.6",
  "gtk4-sys",
  "libc",
@@ -2472,9 +2440,9 @@ dependencies = [
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fc329e1457d97a9d58a4e2ca49e3be572431a7e096008efc2e3a3c19d428f4"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -2494,18 +2462,18 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.47"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -2770,9 +2738,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -2780,7 +2748,16 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
 dependencies = [
- "logos-derive",
+ "logos-derive 0.15.1",
+]
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive 0.16.1",
 ]
 
 [[package]]
@@ -2800,12 +2777,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
 name = "logos-derive"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
 dependencies = [
- "logos-codegen",
+ "logos-codegen 0.15.1",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen 0.16.1",
 ]
 
 [[package]]
@@ -2834,14 +2834,16 @@ dependencies = [
 
 [[package]]
 name = "mac-notification-sys"
-version = "0.6.12"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
 dependencies = [
  "cc",
+ "log",
  "objc2",
  "objc2-foundation",
  "time",
+ "uuid",
 ]
 
 [[package]]
@@ -2856,15 +2858,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -2902,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.50"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -2937,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2993,9 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3011,9 +3013,9 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "notify-rust"
-version = "4.17.0"
+version = "4.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
 dependencies = [
  "futures-lite",
  "log",
@@ -3066,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3354,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
 dependencies = [
  "android_system_properties",
  "log",
@@ -3370,13 +3372,12 @@ dependencies = [
 
 [[package]]
 name = "pango"
-version = "0.22.6"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251bdc6e6487b811be0e406a21e301e07e45c0aa8fa39e00c0c8e12a91752438"
+checksum = "5d800d8d0de2ad5d0fb046f5344dbaba14a003cf3dd27cc21d85893d35ea316c"
 dependencies = [
- "gio 0.22.6",
- "glib 0.22.7",
- "libc",
+ "gio 0.22.8",
+ "glib 0.22.8",
  "pango-sys",
 ]
 
@@ -3386,7 +3387,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd111a20ca90fedf03e09c59783c679c00900f1d8491cca5399f5e33609d5d6"
 dependencies = [
- "glib-sys 0.22.6",
+ "glib-sys 0.22.8",
  "gobject-sys 0.22.6",
  "libc",
  "system-deps",
@@ -3501,16 +3502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,9 +3521,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3540,9 +3531,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools",
@@ -3553,11 +3544,11 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+checksum = "590aa145fee8f7a26b5a6055365e7c5e89a5c1caae9869de76ec0ee73181a2f9"
 dependencies = [
- "logos",
+ "logos 0.16.1",
  "miette",
  "prost",
  "prost-types",
@@ -3565,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
@@ -3593,7 +3584,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
 dependencies = [
- "logos",
+ "logos 0.15.1",
  "miette",
  "prost-types",
  "thiserror 2.0.18",
@@ -3635,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3655,9 +3646,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -3691,9 +3682,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3744,7 +3735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3849,9 +3840,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3872,9 +3863,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relm4"
@@ -3954,9 +3945,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -4045,9 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "rsqlite-vfs"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
@@ -4104,9 +4095,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4119,9 +4110,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -4131,9 +4122,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4331,9 +4322,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -4376,9 +4367,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -4396,9 +4387,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4464,9 +4455,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4524,15 +4515,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4558,9 +4549,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
 dependencies = [
  "cc",
  "js-sys",
@@ -4588,9 +4579,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4673,9 +4664,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tauri-winrt-notification"
@@ -4696,7 +4687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4753,12 +4744,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -4770,15 +4760,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4848,9 +4838,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-socks"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+checksum = "a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615"
 dependencies = [
  "either",
  "futures-util",
@@ -4909,9 +4899,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -4951,9 +4941,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -5061,9 +5051,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typewit"
@@ -5119,12 +5109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5175,11 +5159,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5242,27 +5226,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5273,9 +5248,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5283,9 +5258,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5293,9 +5268,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5306,33 +5281,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -5359,18 +5312,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -5401,9 +5342,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.12"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
  "bitflags",
  "wayland-backend",
@@ -5435,9 +5376,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5455,18 +5396,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5888,97 +5829,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -5997,15 +5850,15 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6026,9 +5879,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -6061,9 +5914,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6087,18 +5940,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6128,9 +5981,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -6168,9 +6021,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"
@@ -6208,9 +6061,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.11.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
 dependencies = [
  "endi",
  "enumflags2",
@@ -6222,9 +6075,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.11.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6235,9 +6088,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -51,6 +51,36 @@ We will work on wider distributions support once more games will be supported.
 | [Flatpak](https://github.com/an-anime-team/agl-flatpak)            | Fedora Workstation, etc.                        |
 | [AUR](https://aur.archlinux.org/packages/anime-games-launcher-bin) | Arch Linux, CachyOS, Manjaro, EndeavourOS, etc. |
 
+### NixOS
+
+We provide official nix flake for installing the launcher:
+
+```nix
+{
+    inputs = {
+        # Add launcher flake as input
+        anime-games-launcher.url = "github:an-anime-team/anime-games-launcher";
+    };
+
+    outputs = { anime-games-launcher, ... }: {
+        nixosConfigurations.default = nixpkgs.lib.nixosSystem {
+            modules = [
+                # Add launcher's nixos module from the flake
+                anime-games-launcher.nixosModules.anime-games-launcher
+
+                # Add the launcher or anirun CLI
+                ({ ... }: {
+                    programs.anime-games-launcher = {
+                        enable = true;
+                        anirun.enable = true;
+                    };
+                })
+            ];
+        };
+    };
+}
+```
+
 ## Useful links
 
 - [Packages manager documentation](./crates/agl-packages/README.md)

--- a/crates/agl-core/Cargo.toml
+++ b/crates/agl-core/Cargo.toml
@@ -100,7 +100,8 @@ features = [
     "zstd",
     "deflate",
     "stream",
-    "socks"
+    "socks",
+    "system-proxy"
 ]
 optional = true
 

--- a/crates/agl-core/Cargo.toml
+++ b/crates/agl-core/Cargo.toml
@@ -81,7 +81,6 @@ default = [
 ]
 
 [dependencies.tokio]
-package = "tokio"
 version = "1.52"
 features = [
     "rt-multi-thread",
@@ -92,7 +91,6 @@ features = [
 optional = true
 
 [dependencies.reqwest]
-package = "reqwest"
 version = "0.13"
 features = [
     "gzip",

--- a/crates/agl-games/Cargo.toml
+++ b/crates/agl-games/Cargo.toml
@@ -6,6 +6,10 @@ license = "GPL-3.0-or-later"
 edition = "2024"
 publish = false
 
+[features]
+default = ["tracing"]
+tracing = ["dep:tracing"]
+
 [dependencies]
 agl-locale = { path = "../agl-locale" }
 
@@ -16,3 +20,6 @@ serde_json = "1.0"
 os_info = "3.14"
 
 mlua = { version = "0.11", features = ["luau-jit"] }
+
+# Tracing
+tracing = { version = "0.1", optional = true }

--- a/crates/agl-games/README.md
+++ b/crates/agl-games/README.md
@@ -293,13 +293,19 @@ type SettingsEntryNumber = {
 
 type SettingsEntryEnum = {
     format: 'enum';
-    values: { [name: string]: LocalizableString };
+    values: {
+        name: string,
+        title: LocalizableString
+    }[];
     selected: string;
 };
 
 type SettingsEntrySelector = {
     format: 'selector';
-    values: { [name: string]: LocalizableString };
+    values: {
+        name: string,
+        title: LocalizableString
+    }[];
     selected: string;
 };
 

--- a/crates/agl-games/src/api/game_settings.rs
+++ b/crates/agl-games/src/api/game_settings.rs
@@ -260,26 +260,54 @@ impl GameSettingsEntryFormat {
                     .and_then(|values| {
                         let mut table = Vec::with_capacity(values.raw_len());
 
-                        values.for_each::<String, LuaValue>(|key, value| {
-                            table.push((
-                                key,
-                                LocalizableString::from_lua(&value)?
-                            ));
+                        // Old format (name -> title table).
+                        for pair in values.pairs::<LuaValue, LuaValue>() {
+                            let pair = pair?;
 
-                            Ok(())
-                        })?;
+                            // Skip integer fields (sequence values).
+                            if let LuaValue::String(name) = pair.0 {
+                                table.push((
+                                    name.to_string_lossy(),
+                                    LocalizableString::from_lua(&pair.1)?
+                                ));
+                            }
+                        }
 
-                        // Returned lua table is not sorted properly so we're
-                        // kinda solving it here.
+                        // Sort old format entries by their title since
+                        // hashmap-like tables don't preserve original items
+                        // order.
                         table.sort_by(|a, b| {
                             b.1.default_translation()
                                 .cmp(a.1.default_translation())
                         });
 
+                        // New format ({ name, title } objects).
+                        for value in values.sequence_values::<LuaTable>() {
+                            let value = value?;
+
+                            // Support "key" field although only "name" is
+                            // correct.
+                            let name = value.raw_get::<String>("name")
+                                .or_else(|_| value.raw_get::<String>("key"))?;
+
+                            // Support "value" field although only "title" is
+                            // correct.
+                            let title = value.raw_get::<LuaValue>("title")
+                                .or_else(|_| value.raw_get::<LuaValue>("value"))?;
+
+                            table.push((
+                                name,
+                                LocalizableString::from_lua(&title)?
+                            ));
+                        }
+
                         Ok(table.into_boxed_slice())
                     })?,
 
-                selected: value.get("selected")?
+                // Support "value" field for consistency, although "selected"
+                // is the only correct one.
+                selected: value.get("selected")
+                    .or_else(|_| value.get("value"))?
             }),
 
             "selector" => Ok(Self::Selector {
@@ -287,26 +315,54 @@ impl GameSettingsEntryFormat {
                     .and_then(|values| {
                         let mut table = Vec::with_capacity(values.raw_len());
 
-                        values.for_each::<String, LuaValue>(|key, value| {
-                            table.push((
-                                key,
-                                LocalizableString::from_lua(&value)?
-                            ));
+                        // Old format (name -> title table).
+                        for pair in values.pairs::<LuaValue, LuaValue>() {
+                            let pair = pair?;
 
-                            Ok(())
-                        })?;
+                            // Skip integer fields (sequence values).
+                            if let LuaValue::String(name) = pair.0 {
+                                table.push((
+                                    name.to_string_lossy(),
+                                    LocalizableString::from_lua(&pair.1)?
+                                ));
+                            }
+                        }
 
-                        // Returned lua table is not sorted properly so we're
-                        // kinda solving it here.
+                        // Sort old format entries by their title since
+                        // hashmap-like tables don't preserve original items
+                        // order.
                         table.sort_by(|a, b| {
-                            a.1.default_translation()
-                                .cmp(b.1.default_translation())
+                            b.1.default_translation()
+                                .cmp(a.1.default_translation())
                         });
+
+                        // New format ({ name, title } objects).
+                        for value in values.sequence_values::<LuaTable>() {
+                            let value = value?;
+
+                            // Support "key" field although only "name" is
+                            // correct.
+                            let name = value.raw_get::<String>("name")
+                                .or_else(|_| value.raw_get::<String>("key"))?;
+
+                            // Support "value" field although only "title" is
+                            // correct.
+                            let title = value.raw_get::<LuaValue>("title")
+                                .or_else(|_| value.raw_get::<LuaValue>("value"))?;
+
+                            table.push((
+                                name,
+                                LocalizableString::from_lua(&title)?
+                            ));
+                        }
 
                         Ok(table.into_boxed_slice())
                     })?,
 
-                selected: value.get("selected")?
+                // Support "value" field for consistency, although "selected"
+                // is the only correct one.
+                selected: value.get("selected")
+                    .or_else(|_| value.get("value"))?
             }),
 
             "expandable" => Ok(Self::Expandable {

--- a/crates/agl-games/src/api/game_settings.rs
+++ b/crates/agl-games/src/api/game_settings.rs
@@ -273,6 +273,11 @@ impl GameSettingsEntryFormat {
                             }
                         }
 
+                        #[cfg(feature = "tracing")]
+                        if !table.is_empty() {
+                            tracing::warn!("using outdated enum settings entry values syntax");
+                        }
+
                         // Sort old format entries by their title since
                         // hashmap-like tables don't preserve original items
                         // order.
@@ -326,6 +331,11 @@ impl GameSettingsEntryFormat {
                                     LocalizableString::from_lua(&pair.1)?
                                 ));
                             }
+                        }
+
+                        #[cfg(feature = "tracing")]
+                        if !table.is_empty() {
+                            tracing::warn!("using outdated selector settings entry values syntax");
                         }
 
                         // Sort old format entries by their title since

--- a/crates/agl-packages/src/storage.rs
+++ b/crates/agl-packages/src/storage.rs
@@ -181,6 +181,19 @@ impl Storage {
         self.resource_path(hash).exists()
     }
 
+    /// Remove resource file or directory under the given hash if it exists.
+    pub async fn remove_resource(&self, hash: &Hash) -> std::io::Result<()> {
+        let path = self.resource_path(hash);
+
+        if path.is_file() || path.is_symlink() {
+            tasks::fs::remove_file(path).await?;
+        } else if path.is_dir() {
+            tasks::fs::remove_dir_all(path).await?;
+        }
+
+        Ok(())
+    }
+
     /// Verify that resource content for provided hash is valid.
     ///
     /// If resource with provided hash is not stored, then `Ok(false)` is

--- a/crates/agl-packages/src/storage.rs
+++ b/crates/agl-packages/src/storage.rs
@@ -25,6 +25,7 @@ use agl_core::network::downloader::{
     Downloader, DownloadOptions, DownloaderError
 };
 
+use agl_core::tasks;
 use agl_core::archives::{Archive, ArchiveFormat, ArchiveError};
 
 use crate::hash::Hash;
@@ -104,7 +105,7 @@ impl Storage {
     }
 
     /// Get storage folder path.
-    #[inline]
+    #[inline(always)]
     pub fn path(&self) -> &Path {
         &self.path
     }
@@ -120,32 +121,40 @@ impl Storage {
     /// untouched.
     ///
     /// Return hash of the stored resource.
-    pub fn store_resource(&self, path: impl Into<PathBuf>) -> std::io::Result<Hash> {
-        fn try_copy(source: &Path, target: &Path) -> std::io::Result<()> {
+    pub async fn store_resource(
+        &self,
+        path: impl Into<PathBuf>
+    ) -> std::io::Result<Hash> {
+        async fn try_copy(
+            source: PathBuf,
+            target: PathBuf
+        ) -> std::io::Result<()> {
             if source.is_file() {
-                std::fs::copy(source, target)?;
+                tasks::fs::copy(source, target).await?;
             }
 
             else if source.is_dir() {
-                std::fs::create_dir_all(target)?;
+                tasks::fs::create_dir_all(&target).await?;
 
                 for entry in source.read_dir()? {
                     let entry = entry?;
 
-                    try_copy(&entry.path(), &target.join(entry.file_name()))?;
+                    Box::pin(try_copy(
+                        entry.path(),
+                        target.join(entry.file_name())
+                    )).await?;
                 }
             }
 
             else if source.is_symlink() {
                 // FIXME: only works on unix systems while we target to support
                 //        all the OSes.
-
                 #[allow(clippy::collapsible_if)]
                 if let Some(source_filename) = source.file_name() {
-                    std::os::unix::fs::symlink(
+                    tasks::fs::symlink(
                         source.read_link()?,
                         target.join(source_filename)
-                    )?;
+                    ).await?;
                 }
             }
 
@@ -158,7 +167,7 @@ impl Storage {
         let hash = Hash::from_path(path.clone())?;
 
         // Copy the resource into the storage folder.
-        try_copy(&path, &self.resource_path(&hash))?;
+        try_copy(path, self.resource_path(&hash)).await?;
 
         Ok(hash)
     }
@@ -286,7 +295,9 @@ impl Storage {
 
             for package_url in packages_queue.drain(..) {
                 // Skip already downloaded packages.
-                if processed_resources.contains(&(package_url.clone(), ResourceFormat::Package)) {
+                if processed_resources.contains(
+                    &(package_url.clone(), ResourceFormat::Package)
+                ) {
                     continue;
                 }
 
@@ -317,7 +328,7 @@ impl Storage {
                 task.wait().await?;
 
                 // Read the manifest file and calculate its hash.
-                let manifest = std::fs::read(&temp_path)?;
+                let manifest = tasks::fs::read(&temp_path).await?;
                 let manifest_hash = Hash::from_bytes(&manifest);
 
                 // Deserialize package manifest.
@@ -332,13 +343,15 @@ impl Storage {
                     })?;
 
                 // Store the manifest in the storage.
-                self.store_resource(&temp_path)?;
+                self.store_resource(&temp_path).await?;
 
                 // Delete temporary file.
-                let _ = std::fs::remove_file(&temp_path);
+                let _ = tasks::fs::remove_file(&temp_path).await;
 
                 // List this package as processed.
-                processed_resources.insert((package_url.clone(), ResourceFormat::Package));
+                processed_resources.insert(
+                    (package_url.clone(), ResourceFormat::Package)
+                );
 
                 // Link requested URL with its output hash.
                 resource_hashes.insert(package_url.clone(), manifest_hash);
@@ -446,7 +459,9 @@ impl Storage {
 
             for (resource_url, resource_format, resource_info) in resources_queue.drain(..) {
                 // Skip already downloaded resources.
-                if processed_resources.contains(&(resource_url.clone(), resource_format)) {
+                if processed_resources.contains(
+                    &(resource_url.clone(), resource_format)
+                ) {
                     continue;
                 }
 
@@ -499,7 +514,7 @@ impl Storage {
                             && resource_hash != expected_hash
                         {
                             // Delete temporary file.
-                            let _ = std::fs::remove_file(&temp_path);
+                            let _ = tasks::fs::remove_file(&temp_path).await;
 
                             return Err(InstallPackagesError::ResourceHashMismatch {
                                 actual: resource_hash,
@@ -509,10 +524,10 @@ impl Storage {
                         }
 
                         // Store the downloaded file.
-                        self.store_resource(&temp_path)?;
+                        self.store_resource(&temp_path).await?;
 
                         // Delete temporary file.
-                        let _ = std::fs::remove_file(&temp_path);
+                        let _ = tasks::fs::remove_file(&temp_path).await;
 
                         // List this resource as processed.
                         processed_resources.insert((resource_url.clone(), resource_format));
@@ -528,7 +543,7 @@ impl Storage {
                         // Prepare temporary archive extraction folder.
                         let temp_extract_path = self.resource_path(&Hash::rand());
 
-                        std::fs::create_dir_all(&temp_extract_path)?;
+                        tasks::fs::create_dir_all(&temp_extract_path).await?;
 
                         // Try to predict the format of the archive from its
                         // download URL. It's needed because `temp_path` doesn't
@@ -550,7 +565,7 @@ impl Storage {
                         archive.extract(&temp_extract_path)?.wait()?;
 
                         // Delete temporary file.
-                        let _ = std::fs::remove_file(&temp_path);
+                        let _ = tasks::fs::remove_file(&temp_path).await;
 
                         // Calculate hash of the extracted archive.
                         let resource_hash = Hash::from_path(&temp_extract_path)?;
@@ -562,7 +577,7 @@ impl Storage {
                         {
                             // Delete temporary extraction folder.
                             // (damn that's a scary function...)
-                            let _ = std::fs::remove_dir_all(&temp_extract_path);
+                            let _ = tasks::fs::remove_dir_all(&temp_extract_path).await;
 
                             return Err(InstallPackagesError::ResourceHashMismatch {
                                 actual: resource_hash,
@@ -575,10 +590,10 @@ impl Storage {
                         // one.
                         //
                         // TODO: make sane use of store_resource here somehow
-                        std::fs::rename(
+                        tasks::fs::rename(
                             temp_extract_path,
                             self.resource_path(&resource_hash)
-                        )?;
+                        ).await?;
 
                         // List this resource as processed.
                         processed_resources.insert((resource_url.clone(), resource_format));

--- a/crates/agl-runtime/docs/05_filesystem_api.md
+++ b/crates/agl-runtime/docs/05_filesystem_api.md
@@ -48,11 +48,13 @@ Read metadata of the filesystem path (file, directory or a symlink).
 type EntryType = 'file' | 'directory' | 'symlink';
 
 type Metadata = {
-    // UTC timestamp of the creation time.
-    created_at: number;
+    // UTC timestamp of the creation time. Set to nil if creation timestamp is
+    // not supported by the filesystem.
+    created_at: number?;
 
-    // UTC timestamp of the modification time.
-    modified_at: number;
+    // UTC timestamp of the modification time. Set to nil if modification
+    // timestamp is not supported by the filesystem.
+    modified_at: number?;
 
     // Length in bytes of the filesystem entry. For files it's equal to the 
     // file's size. Currently symlink and directory lengths are undefined.

--- a/crates/agl-runtime/docs/05_filesystem_api.md
+++ b/crates/agl-runtime/docs/05_filesystem_api.md
@@ -56,6 +56,10 @@ type Metadata = {
     // timestamp is not supported by the filesystem.
     modified_at: number?;
 
+    // UTC timestamp of the access time. Set to nil if access timestamp is not
+    // supported by the filesystem.
+    accessed_at: number?;
+
     // Length in bytes of the filesystem entry. For files it's equal to the 
     // file's size. Currently symlink and directory lengths are undefined.
     length: number;

--- a/crates/agl-runtime/docs/README.md
+++ b/crates/agl-runtime/docs/README.md
@@ -41,8 +41,14 @@ Runtime also provides the `import` function. Unlike `load`, it will keep only
 resource values respecting their formats:
 
 ```luau
-print(import("file-input")) -- "<path to the file>"
-print(import("package-input")) -- { module: module_value, .. }
+dbg(import("file-input")) -- "<path to the file>"
+dbg(import("package-input")) -- { module: module_value, .. }
+```
+
+You can also import an output of a package:
+
+```luau
+dbg(import("package-input/my-module"))
 ```
 
 ## Values cloning

--- a/crates/agl-runtime/docs/README.md
+++ b/crates/agl-runtime/docs/README.md
@@ -37,6 +37,14 @@ print(file.hash)   -- "<base32 value>"
 print(file.value)  -- "<path to the file>"
 ```
 
+Runtime also provides the `import` function. Unlike `load`, it will keep only
+resource values respecting their formats:
+
+```luau
+print(import("file-input")) -- "<path to the file>"
+print(import("package-input")) -- { module: module_value, .. }
+```
+
 ## Values cloning
 
 Since tables in lua work similarly to arrays in JS (they're shared on cloning)

--- a/crates/agl-runtime/src/api/filesystem_api.rs
+++ b/crates/agl-runtime/src/api/filesystem_api.rs
@@ -103,7 +103,7 @@ impl FilesystemApi {
 
                     let metadata = path.metadata()?;
 
-                    let result = lua.create_table_with_capacity(0, 5)?;
+                    let result = lua.create_table_with_capacity(0, 6)?;
 
                     result.raw_set("created_at", {
                         metadata.created().ok()
@@ -117,6 +117,16 @@ impl FilesystemApi {
 
                     result.raw_set("modified_at", {
                         metadata.modified().ok()
+                            .and_then(|modified_at| {
+                                modified_at.duration_since(UNIX_EPOCH)
+                                    .as_ref()
+                                    .map(Duration::as_secs)
+                                    .ok()
+                            })
+                    })?;
+
+                    result.raw_set("accessed_at", {
+                        metadata.accessed().ok()
                             .and_then(|modified_at| {
                                 modified_at.duration_since(UNIX_EPOCH)
                                     .as_ref()

--- a/crates/agl-runtime/src/api/filesystem_api.rs
+++ b/crates/agl-runtime/src/api/filesystem_api.rs
@@ -106,19 +106,23 @@ impl FilesystemApi {
                     let result = lua.create_table_with_capacity(0, 5)?;
 
                     result.raw_set("created_at", {
-                        metadata.created()?
-                            .duration_since(UNIX_EPOCH)
-                            .as_ref()
-                            .map(Duration::as_secs)
-                            .unwrap_or_default()
+                        metadata.created().ok()
+                            .and_then(|created_at| {
+                                created_at.duration_since(UNIX_EPOCH)
+                                    .as_ref()
+                                    .map(Duration::as_secs)
+                                    .ok()
+                            })
                     })?;
 
                     result.raw_set("modified_at", {
-                        metadata.modified()?
-                            .duration_since(UNIX_EPOCH)
-                            .as_ref()
-                            .map(Duration::as_secs)
-                            .unwrap_or_default()
+                        metadata.modified().ok()
+                            .and_then(|modified_at| {
+                                modified_at.duration_since(UNIX_EPOCH)
+                                    .as_ref()
+                                    .map(Duration::as_secs)
+                                    .ok()
+                            })
                     })?;
 
                     result.raw_set("length", metadata.len())?;

--- a/crates/agl-runtime/src/api/system_api.rs
+++ b/crates/agl-runtime/src/api/system_api.rs
@@ -39,7 +39,7 @@ impl SystemApi {
                 "rfc3339" => time.format(&time::format_description::well_known::Rfc3339),
 
                 _ => {
-                    let format = time::format_description::parse(&format)
+                    let format = time::format_description::parse_borrowed::<3>(&format)
                         .map_err(|err| {
                             LuaError::external(format!("failed to parse time formatting: {err}"))
                         })?;

--- a/crates/agl-runtime/src/runtime.rs
+++ b/crates/agl-runtime/src/runtime.rs
@@ -144,8 +144,11 @@ impl Runtime {
             scope: Arc::new(RwLock::new(scope))
         })?;
 
-        // Load referenced value.
-        env.set("load", self.lua.create_function(move |lua, name: String| -> Result<LuaValue, LuaError> {
+        fn load_value(
+            lua: &Lua,
+            name: &str,
+            module_key: &str
+        ) -> Result<LuaValue, LuaError> {
             // Read the engine table from the registry key.
             let engine_table = lua.named_registry_value::<LuaTable>("engine")?;
 
@@ -154,16 +157,16 @@ impl Runtime {
             let refs_table = engine_table.raw_get::<LuaTable>("refs")?;
 
             // If current module doesn't reference any values - return `nil`.
-            if !refs_table.contains_key(module_key.as_str())? {
+            if !refs_table.contains_key(module_key)? {
                 return Ok(LuaValue::Nil);
             }
 
             // Read the module's references.
-            let module_refs_table = refs_table.raw_get::<LuaTable>(module_key.as_str())?;
+            let module_refs_table = refs_table.raw_get::<LuaTable>(module_key)?;
 
             // If current module doesn't have reference with provided name -
             // return `nil`.
-            if !module_refs_table.contains_key(name.as_str())? {
+            if !module_refs_table.contains_key(name)? {
                 return Ok(LuaValue::Nil);
             }
 
@@ -172,6 +175,69 @@ impl Runtime {
 
             // Read the referenced value.
             values_table.raw_get(ref_key)
+        }
+
+        // Load referenced value.
+        {
+            let module_key = module_key.clone();
+
+            env.set("load", self.lua.create_function(move |lua: &Lua, name: String| -> Result<LuaValue, LuaError> {
+                load_value(lua, name.as_str(), module_key.as_str())
+            })?)?;
+        }
+
+        // Import a resource. Unlike load, this function unpacks the actual
+        // resource value, stripping down all the metadata.
+        env.set("import", self.lua.create_function(move |lua: &Lua, name: String| -> Result<LuaValue, LuaError> {
+            // Stored resource should have `hash`, `format` and `value` fields.
+            let value = load_value(lua, name.as_str(), module_key.as_str())?;
+
+            // If it's not a table then return it as is.
+            let Some(module) = value.as_table() else {
+                return Ok(value);
+            };
+
+            match module.raw_get::<String>("format") {
+                // Packages' outputs store resources in hash/format/value format
+                // so we need to unpack them.
+                Ok(format) if format == "package" => {
+                    let Ok(outputs) = module.raw_get::<LuaTable>("value") else {
+                        return Ok(value);
+                    };
+
+                    let values = lua.create_table_with_capacity(0, outputs.raw_len())?;
+
+                    for pair in outputs.pairs::<LuaString, LuaValue>() {
+                        let (name, output) = pair?;
+
+                        // If package output has `value` field then store it.
+                        if let Some(output) = output.as_table()
+                            && let Ok(value) = output.raw_get::<LuaValue>("value")
+                        {
+                            values.raw_set(name, value)?;
+                        }
+
+                        // Otherwise store the whole output.
+                        else {
+                            values.raw_set(name, output)?;
+                        }
+                    }
+
+                    Ok(LuaValue::Table(values))
+                }
+
+                Ok(_) => {
+                    // Return either `resource.value` or just `resource`.
+                    let value = module.raw_get::<LuaValue>("value")
+                        .unwrap_or(value);
+
+                    Ok(value)
+                }
+
+                // If no `resource.format` field found then return just
+                // `resource`.
+                Err(_) => Ok(value)
+            }
         })?)?;
 
         Ok(env)

--- a/crates/agl-runtime/src/runtime.rs
+++ b/crates/agl-runtime/src/runtime.rs
@@ -187,57 +187,85 @@ impl Runtime {
         }
 
         // Import a resource. Unlike load, this function unpacks the actual
-        // resource value, stripping down all the metadata.
+        // resource value, stripping down all the metadata. The name can contain
+        // path to nested resources within packages by using "/" character.
         env.set("import", self.lua.create_function(move |lua: &Lua, name: String| -> Result<LuaValue, LuaError> {
-            // Stored resource should have `hash`, `format` and `value` fields.
-            let value = load_value(lua, name.as_str(), module_key.as_str())?;
+            fn unpack_resource(
+                lua: &Lua,
+                value: LuaValue
+            ) -> Result<LuaValue, LuaError> {
+                // If it's not a table then return it as is.
+                let Some(resource) = value.as_table() else {
+                    return Ok(value);
+                };
 
-            // If it's not a table then return it as is.
-            let Some(module) = value.as_table() else {
-                return Ok(value);
-            };
+                match resource.raw_get::<String>("format") {
+                    // Packages' outputs store resources in hash/format/value format
+                    // so we need to unpack them.
+                    Ok(format) if format == "package" => {
+                        let Ok(outputs) = resource.raw_get::<LuaTable>("value") else {
+                            return Ok(value);
+                        };
 
-            match module.raw_get::<String>("format") {
-                // Packages' outputs store resources in hash/format/value format
-                // so we need to unpack them.
-                Ok(format) if format == "package" => {
-                    let Ok(outputs) = module.raw_get::<LuaTable>("value") else {
-                        return Ok(value);
-                    };
+                        let values = lua.create_table_with_capacity(0, outputs.raw_len())?;
 
-                    let values = lua.create_table_with_capacity(0, outputs.raw_len())?;
+                        for pair in outputs.pairs::<LuaString, LuaValue>() {
+                            let (name, output) = pair?;
 
-                    for pair in outputs.pairs::<LuaString, LuaValue>() {
-                        let (name, output) = pair?;
+                            // If package output has `value` field then store it.
+                            if let Some(output) = output.as_table()
+                                && let Ok(value) = output.raw_get::<LuaValue>("value")
+                            {
+                                values.raw_set(name, value)?;
+                            }
 
-                        // If package output has `value` field then store it.
-                        if let Some(output) = output.as_table()
-                            && let Ok(value) = output.raw_get::<LuaValue>("value")
-                        {
-                            values.raw_set(name, value)?;
+                            // Otherwise store the whole output.
+                            else {
+                                values.raw_set(name, output)?;
+                            }
                         }
 
-                        // Otherwise store the whole output.
-                        else {
-                            values.raw_set(name, output)?;
-                        }
+                        Ok(LuaValue::Table(values))
                     }
 
-                    Ok(LuaValue::Table(values))
+                    Ok(_) => {
+                        // Return either `resource.value` or just `resource`.
+                        let value = resource.raw_get::<LuaValue>("value")
+                            .unwrap_or(value);
+
+                        Ok(value)
+                    }
+
+                    // If no `resource.format` field found then return just
+                    // `resource`.
+                    Err(_) => Ok(value)
                 }
-
-                Ok(_) => {
-                    // Return either `resource.value` or just `resource`.
-                    let value = module.raw_get::<LuaValue>("value")
-                        .unwrap_or(value);
-
-                    Ok(value)
-                }
-
-                // If no `resource.format` field found then return just
-                // `resource`.
-                Err(_) => Ok(value)
             }
+
+            let (name, mut path) = name.split_once('/').unwrap_or((&name, ""));
+
+            let mut value = load_value(lua, name, module_key.as_str())?;
+
+            // FIXME: currently only 1-level import paths will be resolved
+            //        properly.
+            value = unpack_resource(lua, value)?;
+
+            while !path.is_empty() {
+                let (name, suffix) = path.split_once('/').unwrap_or((path, ""));
+
+                let Some(outputs) = value.as_table() else {
+                    return Err(LuaError::external("no output for given import path"));
+                };
+
+                let Ok(output) = outputs.raw_get::<LuaValue>(name) else {
+                    return Err(LuaError::external("no output for given import path"));
+                };
+
+                path = suffix;
+                value = output;
+            }
+
+            Ok(value)
         })?)?;
 
         Ok(env)

--- a/crates/agl-runtime/src/tests.rs
+++ b/crates/agl-runtime/src/tests.rs
@@ -213,7 +213,7 @@ fn nested_package() -> Result<(), Box<dyn std::error::Error>> {
         runtime.load_packages(&lock, &storage, &paths, &allow_list)?;
 
         // Find some better and standardized way for querying loaded modules.
-        let Some(module) = runtime.get_value::<LuaTable>("op5h5fuc7kqr4#module")? else {
+        let Some(module) = runtime.get_value::<LuaTable>("fgkua9vq5ra7q#module")? else {
             panic!("missing loaded module value");
         };
 

--- a/crates/agl-runtime/tests/nested_package/module_2.luau
+++ b/crates/agl-runtime/tests/nested_package/module_2.luau
@@ -1,11 +1,9 @@
 return function()
     -- obtain package_1 outputs
-    -- { hash, format, value }
-    local package_1 = load("package_1").value
+    local package_1 = import("package_1")
 
     -- obtain function from module_1 output of the package_1
-    -- { hash, format, value }
-    local module_1 = package_1.module_1.value
+    local module_1 = package_1.module_1
 
     return `Counter: {module_1()}`
 end

--- a/crates/agl-runtime/tests/nested_package/package_2.json
+++ b/crates/agl-runtime/tests/nested_package/package_2.json
@@ -9,7 +9,7 @@
     "outputs": {
         "module_2": {
             "uri": "module_2.luau",
-            "hash": "op5h5fuc7kqr4"
+            "hash": "fgkua9vq5ra7q"
         }
     }
 }

--- a/crates/anime-games-launcher/assets/anime-games-launcher.desktop
+++ b/crates/anime-games-launcher/assets/anime-games-launcher.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Anime Games Launcher
-Icon=icon
-Exec=AppRun
+Icon=moe.launcher.anime-games-launcher
+Exec=anime-games-launcher
 Type=Application
 Categories=Game
 Terminal=false

--- a/crates/anime-games-launcher/assets/locales/error_messages.toml
+++ b/crates/anime-games-launcher/assets/locales/error_messages.toml
@@ -15,6 +15,7 @@ pt = "Falha ao carregar pacote do jogo {title}"
 de = "Spielpaket für {title} konnte nicht geladen werden"
 id = "Gagal memuat paket untuk game {title}"
 it = "Impossibile caricare il pacchetto del gioco {title}"
+ja = "{title} ゲームパッケージの読み込みに失敗しました"
 
 [failed_find_locked_game_integration_title]
 en = "Failed to find game integration module in package lock"
@@ -71,6 +72,7 @@ pt = "Falha ao matar o processo em execução do jogo"
 de = "Der Laufende Spielprozess konnten nicht beendet werden"
 id = "Gagal mematikan proses game yang sedang berjalan"
 it = "Impossibile terminare il processo di gioco in esecuzione"
+ja = "ゲームを強制終了できませんでした"
 
 # ------------------------ Game store page ------------------------
 
@@ -97,6 +99,7 @@ pt = "Falha ao baixar o pacote do jogo"
 de = "Das Spielpaket konnte nicht heruntergeladen werden"
 id = "Gagal mengunduh paket untuk game"
 it = "Impossibile scaricare il pacchetto del gioco"
+ja = "ゲームパッケージをダウンロードできませんでした"
 
 # ------------------------ Game library page ------------------------
 
@@ -123,6 +126,7 @@ pt = "Falha ao apagar pacote do jogo {title}"
 de = "Spielpaket für {title} konnte nicht gelöscht werden"
 id = "Gagal untuk menghapus paket gim {title}"
 it = "Impossibile eliminare il pacchetto del gioco {title}"
+ja = "ゲームパッケージ {title} を削除できませんでした"
 
 # ------------------------ Game components ------------------------
 
@@ -157,6 +161,7 @@ pt = "Falha ao aplicar componente do jogo"
 de = "Spielkomponente konnte nicht angewendet werden"
 id = "Gagal untuk menerapkan komponen gim"
 it = "Impossibile aggiungere il componente al gioco"
+ja = "ゲームコンポーネントを適用できませんでした"
 
 # ------------------------ Game settings ------------------------
 
@@ -217,6 +222,7 @@ pt = "Falha ao executar ação da pipeline"
 de = "Die Pipeline-Action konnte nicht durchgeführt werden"
 id = "Gagal menjalankan instruksi yang diperlukan untuk memuat game"
 it = "Impossibile eseguire l'azione della pipeline"
+ja = "パイプラインアクションを実行できませんでした"
 
 # ------------------------ Portal API ------------------------
 

--- a/crates/anime-games-launcher/assets/locales/error_messages.toml
+++ b/crates/anime-games-launcher/assets/locales/error_messages.toml
@@ -3,72 +3,72 @@
 [failed_execute_startup_task]
 en = "Failed to execute startup task"
 ru = "Не удалось выполнить задачу при запуске лаунчера"
-de = "Startaufgabe könnte nicht ausgeführt werden"
 pt = "Falha ao iniciar a tarefa de inicialização"
+de = "Startaufgabe könnte nicht ausgeführt werden"
 id = "Gagal menjalankan aksi untuk memulai aplikasi"
 it = "Impossibile eseguire l'attività di avvio"
 
 [failed_load_game_package]
 en = "Failed to load {title} game package"
 ru = "Не удалось загрузить игровой пакет {title}"
-de = "Spielpaket für {title} konnte nicht geladen werden"
 pt = "Falha ao carregar pacote do jogo {title}"
+de = "Spielpaket für {title} konnte nicht geladen werden"
 id = "Gagal memuat paket untuk game {title}"
 it = "Impossibile caricare il pacchetto del gioco {title}"
 
 [failed_find_locked_game_integration_title]
 en = "Failed to find game integration module in package lock"
 ru = "Не удалось найти модуль интеграции игры в lock файле игрового пакета"
-de = "Integrationsmodul konnte in der Paket-Lock-Datei nicht gefunden werden"
 pt = "Falha ao encontrar módulo de integração no package lock"
+de = "Integrationsmodul konnte in der Paket-Lock-Datei nicht gefunden werden"
 id = "Gagal menemukan modul integrasi game dalam kunci paket"
 it = "Impossibile trovare il modulo di integrazione del gioco nel package lock"
 
 [failed_find_locked_game_integration_description]
 en = "Attempted to find {title} game integration module, but it's missing in the package lock. Perhaps the lock file is broken"
 ru = "Лаунчер попытался найти модуль интеграции для игры {title}, но его нет в lock файле игрового пакета. Вероятно lock файл сломан"
-de = "Das Integrationsmodul für {title} konnte nicht gefunden werden weil es in der Paket-Lock-Datei fehlt. Möglicherweise ist die Paket-Lock-Datei beschädigt"
 pt = "Houve uma tentativa de encontrar o módulo de integração de {title}, mas está faltando no package lock. Talvez o arquivo de lock esteja quebrado"
+de = "Das Integrationsmodul für {title} konnte nicht gefunden werden weil es in der Paket-Lock-Datei fehlt. Möglicherweise ist die Paket-Lock-Datei beschädigt"
 id = "Mencoba menemukan modul integrasi untuk game {title}, tetapi tidak dapat ditemukan dalam kunci paket. Ada kemungkinan kunci paket rusak"
 it = "È stato cercato il modulo di integrazione del gioco {title}, ma non è presente nel package lock. Il file lock potrebbe essere danneggiato"
 
 [failed_read_runtime_game_integration]
 en = "Failed to read {title} game integration from the runtime"
 ru = "Не удалось прочесть интеграцию игры {title} из движка игровых пакетов"
-de = "Die Spielintegration für {title} konnte nicht aus der Runtime ausgelesen werden"
 pt = "Falha ao ler integração de {title} no runtime"
+de = "Die Spielintegration für {title} konnte nicht aus der Runtime ausgelesen werden"
 id = "Gagal membaca integrasi game {title} dari runtime"
 it = "Impossibile leggere l'integrazione del gioco {title} dal runtime"
 
 [game_integration_module_missing_title]
 en = "Game integration module is missing in the runtime"
 ru = "Модуль интеграции игры отсутствует в движке игровых пакетов"
-de = "Das Spielintegrationsmodul fehlt in der Runtime"
 pt = "Módulo de integração está faltando no runtime"
+de = "Das Spielintegrationsmodul fehlt in der Runtime"
 id = "Modul integrasi game tidak dapat ditemukan pada runtime"
 it = "Il modulo di integrazione del gioco non è presente nel runtime"
 
 [game_integration_module_missing_description]
 en = "Attempted to load {title} game integration, but integration module is missing in the packages runtime"
 ru = "Лаунчер попытался загрузить игру {title}, но модуль интеграции отсутствует в движке игровых пакетов"
-de = "Die Spielintegration für {title} konnte nicht geladen werden weil diese in der Spiel-Runtime fehlt"
 pt = "Houve uma tentativa de carregar a integração do jogo {title}, mas o módulo está faltando no runtime do pacote"
+de = "Die Spielintegration für {title} konnte nicht geladen werden weil diese in der Spiel-Runtime fehlt"
 id = "Mencoba memuat integrasi game {title}, tetapi modul integrasi tidak dapat ditemukan dalam runtime paket"
 it = "È stato tentato il caricamento dell'integrazione del gioco {title}, ma il modulo di integrazione non è presente nel runtime dei pacchetti"
 
 [failed_build_game_integration]
 en = "Failed to build {title} game integration"
 ru = "Не удалось загрузить интеграцию игры {title}"
-de = "Erstellen der Spielintegration für {title} ist gescheitert"
 pt = "Falha ao construir a integração do jogo {title}"
+de = "Erstellen der Spielintegration für {title} ist gescheitert"
 id = "Gagal membuat integrasi game {title}"
 it = "Impossibile compilare l'integrazione del gioco {title}"
 
 [failed_kill_game_process]
 en = "Failed to kill running game process"
 ru = "Не удалось убить процесс игры"
-de = "Der Laufende Spielprozess konnten nicht beendet werden"
 pt = "Falha ao matar o processo em execução do jogo"
+de = "Der Laufende Spielprozess konnten nicht beendet werden"
 id = "Gagal mematikan proses game yang sedang berjalan"
 it = "Impossibile terminare il processo di gioco in esecuzione"
 
@@ -77,24 +77,24 @@ it = "Impossibile terminare il processo di gioco in esecuzione"
 [failed_serialize_game_package_lock]
 en = "Failed to serialize game package lock"
 ru = "Не удалось сериализовать пакет интеграции игры"
-de = "Die Serialisierung der Spielpaketsperrdatei ist gescheitert"
 pt = "Falha ao serializar package lock do jogo"
+de = "Die Serialisierung der Spielpaketsperrdatei ist gescheitert"
 id = "Gagal melakukan serialisasi paket kunci untuk game"
 it = "Impossibile serializzare il package lock del gioco"
 
 [failed_save_game_package_lock]
 en = "Failed to save game package lock"
 ru = "Не удалось сохранить пакет интеграции игры"
-de = "Die Spielpaketsperrdatei konnte nicht gespeichert werden"
 pt = "Falha ao salvar package lock do jogo"
+de = "Die Spielpaketsperrdatei konnte nicht gespeichert werden"
 id = "Gagal menyimpan paket kunci untuk game"
 it = "Impossibile salvare il package lock del gioco"
 
 [failed_download_game_package]
 en = "Failed to download game package"
 ru = "Не удалось скачать пакет интеграции игры"
-de = "Das Spielpaket konnte nicht heruntergeladen werden"
 pt = "Falha ao baixar o pacote do jogo"
+de = "Das Spielpaket konnte nicht heruntergeladen werden"
 id = "Gagal mengunduh paket untuk game"
 it = "Impossibile scaricare il pacchetto del gioco"
 
@@ -103,108 +103,108 @@ it = "Impossibile scaricare il pacchetto del gioco"
 [failed_request_game_launch_info]
 en = "Failed to request game launch info"
 ru = "Не удалось запросить информацию для запуска игры"
-de = "Startinformationen konnten nicht abgefragt werden"
 pt = "Falha ao requisitar informações de execução do jogo"
+de = "Startinformationen konnten nicht abgefragt werden"
 id = "Gagal meminta informasi yang diperlukan untuk meluncurkan game"
 it = "Impossibile richiedere le informazioni di avvio del gioco"
 
 [failed_request_game_actions_pipeline]
 en = "Failed to request game actions pipeline"
 ru = "Не удалось запросить необходимую последовательность действий для игры"
-de = "Das Abfragen der Aktions-Pipeline des Spieles ist gescheitert"
 pt = "Falha ao requisitar pipeline de ações do jogo"
+de = "Das Abfragen der Aktions-Pipeline des Spieles ist gescheitert"
 id = "Gagal meminta instruksi yang diperlukan untuk memuat game"
 it = "Impossibile richiedere la pipeline delle azioni del gioco"
 
 [failed_delete_game_package]
 en = "Failed to delete {title} game package"
 ru = "Не удалось удалить пакет игры {title}"
+pt = "Falha ao apagar pacote do jogo {title}"
 de = "Spielpaket für {title} konnte nicht gelöscht werden"
 id = "Gagal untuk menghapus paket gim {title}"
 it = "Impossibile eliminare il pacchetto del gioco {title}"
-pt = "Falha ao apagar pacote do jogo {title}"
 
 # ------------------------ Game components ------------------------
 
 [failed_request_game_components_layout]
 en = "Failed to request game components layout"
 ru = "Не удалось запросить список компонентов игры"
+pt = "Falha ao requisitar o layout de componentes do jogo"
 de = "Anfrage des Spielkomponentenlayouts ist fehlgeschlagen"
 id = "Gagal untuk memesan susunan komponen gim"
 it = "Impossibile richiedere il layout dei componenti del gioco"
-pt = "Falha ao requisitar o layout de componentes do jogo"
 
 [failed_update_game_components_layout]
 en = "Failed to update game components layout"
 ru = "Не удалось обновить список компонентов игры"
+pt = "Falha ao atualizar o layout de componentes do jogo"
 de = "Aktualisierung des Spielkomponentenlayouts ist fehlgeschlagen"
 id = "Gagal untuk memperbaharui susunan komponen gim"
 it = "Impossibile aggiornare il layout dei componenti del gioco"
-pt = "Falha ao atualizar o layout de componentes do jogo"
 
 [failed_render_game_components]
 en = "Failed to render game components"
 ru = "Не удалось загрузить страницу компонентов игры"
+pt = "Falha ao renderizar os componentes do jogo"
 de = "Rendern der Spielkomponente ist fehlgeschlagen"
 id = "Gagal untuk menampilkan komponen gim"
 it = "Impossibile visualizzare i componenti del gioco"
-pt = "Falha ao renderizar os componentes do jogo"
 
 [failed_apply_game_component]
 en = "Failed to apply game component"
 ru = "Не удалось применить компонент игры"
+pt = "Falha ao aplicar componente do jogo"
 de = "Spielkomponente konnte nicht angewendet werden"
 id = "Gagal untuk menerapkan komponen gim"
 it = "Impossibile aggiungere il componente al gioco"
-pt = "Falha ao aplicar componente do jogo"
 
 # ------------------------ Game settings ------------------------
 
 [failed_request_game_tools_buttons]
 en = "Failed to request game tools buttons"
 ru = "Не удалось запросить список дополнительных инструментов для игры"
+pt = "Falha ao requisitar os botões das ferramentas do jogo"
 de = "Anfrage für die Spielwerkzeugstaste ist fehlgeschlagen"
 id = "Gagal meminta tombol untuk peralatan game"
 it = "Impossibile richiedere i pulsanti degli strumenti del gioco"
-pt = "Falha ao requisitar os botões das ferramentas do jogo"
 
 [failed_call_game_tool_button]
 en = "Failed to call game tool button"
 ru = "Не удалось выполнить дополнительный игровой инструмент"
+pt = "Falha ao acionar botão das ferramentas do jogo"
 de = "Spielwerkzeugstaste konnte nicht aufgerufen werden"
 id = "Gagal memanggil tombol untuk peralatan game"
 it = "Impossibile eseguire il pulsante dello strumento di gioco"
-pt = "Falha ao acionar botão das ferramentas do jogo"
 
 [failed_request_game_settings_layout]
 en = "Failed to request game settings layout"
 ru = "Не удалось запросить список настроек игры"
-de = "Layout der Spieleinstellungen konnte nicht abgefragt werden"
 pt = "Falha ao requisitar layout de configurações do jogo"
+de = "Layout der Spieleinstellungen konnte nicht abgefragt werden"
 id = "Gagal meminta layout untuk pengaturan game"
 it = "Impossibile richiedere il layout delle impostazioni del gioco"
 
 [failed_render_game_settings]
 en = "Failed to render game settings"
 ru = "Не удалось загрузить страницу настроек игры"
-de = "Spieleinstellungen konnten nicht gerendert werden"
 pt = "Falha ao renderizar configurações do jogo"
+de = "Spieleinstellungen konnten nicht gerendert werden"
 id = "Gagal menggambar pengaturan untuk game"
 it = "Impossibile visualizzare le impostazioni del gioco"
 
 [failed_update_game_settings_layout]
 en = "Failed to update game settings layout"
 ru = "Не удалось обновить список настроек игры"
-de = "Das Layouts der Spieleinstellungen konnte nicht aktualisiert werden"
 pt = "Falha ao atualizar layour de configurações do jogo"
+de = "Das Layouts der Spieleinstellungen konnte nicht aktualisiert werden"
 id = "Gagal memperbarui layout untuk pengaturan game"
 it = "Impossibile aggiornare il layout delle impostazioni del gioco"
 
 [failed_set_game_property]
 en = "Failed to set game property value"
 ru = "Не удалось обновить настройки игры"
-de = "Spieleigenschaft konnte nicht gesetzt werden"
 pt = "Falha ao definir valor de uma propriedade do jogo"
+de = "Spieleigenschaft konnte nicht gesetzt werden"
 id = "Gagal menentukan nilai properti dari game"
 it = "Impossibile impostare il valore della proprietà del gioco"
 
@@ -213,8 +213,8 @@ it = "Impossibile impostare il valore della proprietà del gioco"
 [failed_perform_pipeline_action]
 en = "Failed to perform pipeline action"
 ru = "Не удалось выполнить последовательность действий (pipeline action)"
-de = "Die Pipeline-Action konnte nicht durchgeführt werden"
 pt = "Falha ao executar ação da pipeline"
+de = "Die Pipeline-Action konnte nicht durchgeführt werden"
 id = "Gagal menjalankan instruksi yang diperlukan untuk memuat game"
 it = "Impossibile eseguire l'azione della pipeline"
 
@@ -223,23 +223,23 @@ it = "Impossibile eseguire l'azione della pipeline"
 [failed_execute_toast_action]
 en = "Failed to execute toast action"
 ru = "Не удалось выполнить действие во всплывающем уведомлении"
-de = "Toast-Aktion konnte nicht ausgeführt werden"
 pt = "Falha ao executar ação toast"
+de = "Toast-Aktion konnte nicht ausgeführt werden"
 id = "Gagal menjalankan aksi yang ada pada pop-up toast"
 it = "Impossibile eseguire l'azione del toast"
 
 [failed_show_system_notification]
 en = "Failed to show system notification"
 ru = "Не удалось отобразить системное уведомление"
-de = "Systembenachrichtigung konnte nicht angezeigt werden"
 pt = "Falha ao mostrar notificação do sistema"
+de = "Systembenachrichtigung konnte nicht angezeigt werden"
 id = "Gagal menampilkan notifikasi dari sistem"
 it = "Impossibile mostrare la notifica di sistema"
 
 [failed_execute_dialog_action]
 en = "Failed to execute dialog action"
 ru = "Не удалось выполнить действие диалогового окна"
-de = "Dialog-Aktion konnte nicht ausgeführt werden"
 pt = "Falha ao executar ação do diálogo"
+de = "Dialog-Aktion konnte nicht ausgeführt werden"
 id = "Gagal menjalankan aksi yang ada pada dialog"
 it = "Impossibile eseguire l'azione della finestra di dialogo"

--- a/crates/anime-games-launcher/assets/locales/error_messages.toml
+++ b/crates/anime-games-launcher/assets/locales/error_messages.toml
@@ -122,6 +122,7 @@ ru = "Не удалось удалить пакет игры {title}"
 de = "Spielpaket für {title} konnte nicht gelöscht werden"
 id = "Gagal untuk menghapus paket gim {title}"
 it = "Impossibile eliminare il pacchetto del gioco {title}"
+pt = "Falha ao apagar pacote do jogo {title}"
 
 # ------------------------ Game components ------------------------
 
@@ -131,6 +132,7 @@ ru = "Не удалось запросить список компонентов
 de = "Anfrage des Spielkomponentenlayouts ist fehlgeschlagen"
 id = "Gagal untuk memesan susunan komponen gim"
 it = "Impossibile richiedere il layout dei componenti del gioco"
+pt = "Falha ao requisitar o layout de componentes do jogo"
 
 [failed_update_game_components_layout]
 en = "Failed to update game components layout"
@@ -138,6 +140,7 @@ ru = "Не удалось обновить список компонентов �
 de = "Aktualisierung des Spielkomponentenlayouts ist fehlgeschlagen"
 id = "Gagal untuk memperbaharui susunan komponen gim"
 it = "Impossibile aggiornare il layout dei componenti del gioco"
+pt = "Falha ao atualizar o layout de componentes do jogo"
 
 [failed_render_game_components]
 en = "Failed to render game components"
@@ -145,6 +148,7 @@ ru = "Не удалось загрузить страницу компонент
 de = "Rendern der Spielkomponente ist fehlgeschlagen"
 id = "Gagal untuk menampilkan komponen gim"
 it = "Impossibile visualizzare i componenti del gioco"
+pt = "Falha ao renderizar os componentes do jogo"
 
 [failed_apply_game_component]
 en = "Failed to apply game component"
@@ -152,6 +156,7 @@ ru = "Не удалось применить компонент игры"
 de = "Spielkomponente konnte nicht angewendet werden"
 id = "Gagal untuk menerapkan komponen gim"
 it = "Impossibile aggiungere il componente al gioco"
+pt = "Falha ao aplicar componente do jogo"
 
 # ------------------------ Game settings ------------------------
 
@@ -161,6 +166,7 @@ ru = "Не удалось запросить список дополнитель
 de = "Anfrage für die Spielwerkzeugstaste ist fehlgeschlagen"
 id = "Gagal meminta tombol untuk peralatan game"
 it = "Impossibile richiedere i pulsanti degli strumenti del gioco"
+pt = "Falha ao requisitar os botões das ferramentas do jogo"
 
 [failed_call_game_tool_button]
 en = "Failed to call game tool button"
@@ -168,6 +174,7 @@ ru = "Не удалось выполнить дополнительный игр
 de = "Spielwerkzeugstaste konnte nicht aufgerufen werden"
 id = "Gagal memanggil tombol untuk peralatan game"
 it = "Impossibile eseguire il pulsante dello strumento di gioco"
+pt = "Falha ao acionar botão das ferramentas do jogo"
 
 [failed_request_game_settings_layout]
 en = "Failed to request game settings layout"

--- a/crates/anime-games-launcher/assets/locales/game_tags.toml
+++ b/crates/anime-games-launcher/assets/locales/game_tags.toml
@@ -3,16 +3,16 @@
 [game_tag_gambling_title]
 en = "Gambling"
 ru = "Азартные игры"
-de = "Glücksspiel"
 pt = "Apostas"
+de = "Glücksspiel"
 id = "Perjudian"
 it = "Gioco d'azzardo"
 
 [game_tag_gambling_description]
 en = "Game has scenes of gambling or has game mechanics related to gambling (wishes, banners, etc.)"
 ru = "Игра содержит сцены с азартными играми или механики, связанные с азартными играми (например, баннеры с персонажами)"
-de = "Dieses Spiel beinhaltet Szenen mit Glücksspielen oder hat Glücksspielähnliche Spielmechaniken (Gacha, Lootboxen, etc.)"
 pt = "Jogo contém cenas de apostas ou possui mecânicas relacionadas à apostas (orações, banners e etc.)"
+de = "Dieses Spiel beinhaltet Szenen mit Glücksspielen oder hat Glücksspielähnliche Spielmechaniken (Gacha, Lootboxen, etc.)"
 id = "Game memuat konten yang memperagakan perjudian atau memiliki mekanisme yang berhubungan dengan perjudian (wishes, banner, dan lain-lain.)"
 it = "Il gioco contiene scene di gioco d'azzardo o meccaniche legate al gioco d'azzardo (loot box, gachapon, ecc.)"
 
@@ -21,16 +21,16 @@ it = "Il gioco contiene scene di gioco d'azzardo o meccaniche legate al gioco d'
 [game_tag_payments_title]
 en = "Payments"
 ru = "Внутриигровые покупки"
-de = "Zahlungen"
 pt = "Transações"
+de = "Zahlungen"
 id = "Transaksi"
 it = "Pagamenti"
 
 [game_tag_payments_description]
 en = "Game can accept real money for in-game content"
 ru = "Игра может принимать реальные деньги для внутриигрового контента"
-de = "Das Spiel akzeptiert echtes Geld für Spielinhalte"
 pt = "O jogo pode aceitar dinheiro real por conteúdo no jogo"
+de = "Das Spiel akzeptiert echtes Geld für Spielinhalte"
 id = "Game menerima pembayaran menggunakan mata uang asli untuk membeli konten di dalam game"
 it = "Il gioco può richiedere denaro reale per contenuti di gioco"
 
@@ -39,16 +39,16 @@ it = "Il gioco può richiedere denaro reale per contenuti di gioco"
 [game_tag_graphic_violence_title]
 en = "Graphic Violence"
 ru = "Насилие"
-de = "Grafische Gewalt"
 pt = "Violência Gráfica"
+de = "Grafische Gewalt"
 id = "Kekerasan"
 it = "Violenza grafica"
 
 [game_tag_graphic_violence_description]
 en = "Game contains graphic violence"
 ru = "Игра содержит сцены насилия"
-de = "Das Spiel beinhaltet Szenen von grafischer Gewalt"
 pt = "Jogo possui violência representada graficalmente"
+de = "Das Spiel beinhaltet Szenen von grafischer Gewalt"
 id = "Game memuat konten yang menampilkan kekerasan"
 it = "Il gioco contiene scene di violenza grafica"
 
@@ -57,16 +57,16 @@ it = "Il gioco contiene scene di violenza grafica"
 [game_tag_cooperative_title]
 en = "Cooperative"
 ru = "Кооператив"
-de = "Kooperativ"
 pt = "Cooperativo"
+de = "Kooperativ"
 id = "Kooperasi"
 it = "Cooperativo"
 
 [game_tag_cooperative_description]
 en = "Game has built-in multiplayer (cooperative) elements"
 ru = "Игра содержит элементы кооперации с другими игроками"
-de = "Das Spiel beinhaltet integrierte Mehrspieler-Koop-Elemente"
 pt = "O jogo possui elementos de multiplayer cooperativo"
+de = "Das Spiel beinhaltet integrierte Mehrspieler-Koop-Elemente"
 id = "Game memiliki elemen multiplayer (kerjasama)"
 it = "Il gioco include elementi multigiocatore cooperativi integrati"
 
@@ -75,16 +75,16 @@ it = "Il gioco include elementi multigiocatore cooperativi integrati"
 [game_tag_social_title]
 en = "Social"
 ru = "Социальная"
-de = "Sozial"
 pt = "Social"
+de = "Sozial"
 id = "Sosial"
 it = "Sociale"
 
 [game_tag_social_description]
 en = "Game has social features - online chat, VoIP, shared spaces, etc"
 ru = "Игра содержит социальные функции - онлайн чат, голосовое общение, общие комнаты и т.п."
-de = "Das Spiel bietet soziale Funktionen wie Text- oder Sprachchat, gemeinsame Räume, usw."
 pt = "O jogo possui funções sociais - conversas online, VoIP, espaços compartilhados e etc."
+de = "Das Spiel bietet soziale Funktionen wie Text- oder Sprachchat, gemeinsame Räume, usw."
 id = "Game memiliki fitur sosial - online chat, VoIP, shared spaces, etc"
 it = "Il gioco include funzioni sociali, come chat online, VoIP, spazi condivisi, ecc."
 
@@ -93,16 +93,16 @@ it = "Il gioco include funzioni sociali, come chat online, VoIP, spazi condivisi
 [game_tag_controller_title]
 en = "Controller"
 ru = "Контроллер"
-de = "Controller"
 pt = "Controle"
+de = "Controller"
 id = "Kontroller"
 it = "Controller"
 
 [game_tag_controller_description]
 en = "Game has controllers support"
 ru = "Игра имеет поддержку контроллеров"
-de = "Das Spiel unterstützt Controller"
 pt = "O jogo possui suporte nativo à controles"
+de = "Das Spiel unterstützt Controller"
 id = "Game memiliki dukungan untuk kontroller"
 it = "Il gioco supporta i controller"
 
@@ -111,16 +111,16 @@ it = "Il gioco supporta i controller"
 [game_tag_performance_issues_title]
 en = "Performance Issues"
 ru = "Проблемы с производительностью"
-de = "Leistungsprobleme"
 pt = "Problemas de Performance"
+de = "Leistungsprobleme"
 id = "Masalah performa"
 it = "Problemi di prestazioni"
 
 [game_tag_performance_issues_description]
 en = "Game is known to have bad performance on some platforms"
 ru = "Игра имеет плохую производительность на некоторых платформах"
-de = "Das Spiel hat bekanntermaßen eine schlechte Leistung auf einigen Plattformen"
 pt = "O jogo é conhecido por ter problemas de performance em algumas plataformas"
+de = "Das Spiel hat bekanntermaßen eine schlechte Leistung auf einigen Plattformen"
 id = "Game diketahui memiliki performa yang buruk di beberapa platform"
 it = "Il gioco è noto per avere prestazioni scarse su alcune piattaforme"
 
@@ -129,16 +129,16 @@ it = "Il gioco è noto per avere prestazioni scarse su alcune piattaforme"
 [game_tag_anti_cheat_title]
 en = "Anti-cheat"
 ru = "Анти-чит"
-de = "Anti-Cheat"
 pt = "Anti-trapaça"
+de = "Anti-Cheat"
 id = "Anti-Cheat"
 it = "Anti-cheat"
 
 [game_tag_anti_cheat_description]
 en = "Game has an anti-cheat, either server- or client-side"
 ru = "Игра имеет клиентский или серверный анти-чит"
-de = "Das Spiel verwendet ein entweder server- oder clientseitiges Anti-Cheat"
 pt = "O jogo possui um mecanismo de anti-trapaças (anti-cheat), sendo no lado do servidor- ou cliente"
+de = "Das Spiel verwendet ein entweder server- oder clientseitiges Anti-Cheat"
 id = "Game memiliki anti-cheat, baik pada sisi server ataupun sisi klien"
 it = "Il gioco include un sistema anti-cheat, lato server o lato client"
 
@@ -147,15 +147,15 @@ it = "Il gioco include un sistema anti-cheat, lato server o lato client"
 [game_tag_workarounds_title]
 en = "Workarounds"
 ru = "Дополнительные компоненты"
-de = "Workarounds"
 pt = "Gambiarra"
+de = "Workarounds"
 id = "Solusi sementara"
 it = "Soluzioni alternative"
 
 [game_tag_workarounds_description]
 en = "Game cannot run on some platforms natively, but the integration package provides set of special utilities or game files modifications which make the game function. Note that this may violate its terms of service and result in taking actions on your account"
 ru = "Игра не может работать на некоторых платформах, однако модуль интеграции поставляет набор компонентов, необходимых для функционирования игры. Обратите внимание что это может нарушать правила пользования игрой и привести к потере вашего аккаунта"
-de = "Das Spiel läuft nicht nativ auf einigen Plattformen, weshalb das Integrationspaket zusätzlich noch spezielle Hilfsprogramme oder Modifikationen bereitstellt, um das Spiel zum Laufen zu bringen. Beachte jedoch, dass dies gegen die Nutzungsbedingungen des Spieles verstoßen könnte und zu Maßnahmen gegen deinen Account führen kann."
 pt = "O jogo não pode ser executado nativamente em algumas plataformas, mas o pacote de integração provê utilidades especiais ou arquivos modificados do jogo que permitem que o jogo funcione. Perceba que talvez isso viole os Termos de Serviço do jogo, podendo resultar em ações sobre sua conta."
+de = "Das Spiel läuft nicht nativ auf einigen Plattformen, weshalb das Integrationspaket zusätzlich noch spezielle Hilfsprogramme oder Modifikationen bereitstellt, um das Spiel zum Laufen zu bringen. Beachte jedoch, dass dies gegen die Nutzungsbedingungen des Spieles verstoßen könnte und zu Maßnahmen gegen deinen Account führen kann."
 id = "Game tidak dapat dijalankan pada platform tertentu secara langsung, tetapi paket integrasi memberikan aplikasi khusus ataupun memodifikasi file pada game yang dapat membuatnya berfungsu. Patut dipahami bahwa hal tersebut mungkin melanggar ketentuan pelayanan (terms of service) dan dapat memunculkan tindakkan terhadap akun Anda"
 it = "Il gioco non può essere eseguito in modo nativo su alcune piattaforme, ma il pacchetto di integrazione fornisce utilità speciali o modifiche ai file di gioco che lo rendono funzionante. Tieni presente che questo potrebbe violare i termini di servizio e comportare provvedimenti sul tuo account"

--- a/crates/anime-games-launcher/assets/locales/interface.toml
+++ b/crates/anime-games-launcher/assets/locales/interface.toml
@@ -3,48 +3,48 @@
 [continue]
 en = "Continue"
 ru = "Продолжить"
+pt = "Continuar"
 de = "Fortfahren"
 id = "Lanjut"
 it = "Continua"
-pt = "Continuar"
 
 [cancel]
 en = "Cancel"
 ru = "Отменить"
+pt = "Cancelar"
 de = "Abbrechen"
 id = "Batal"
 it = "Annulla"
-pt = "Cancelar"
 
 [close]
 en = "Close"
 ru = "Закрыть"
-de = "Schließen"
 pt = "Fechar"
+de = "Schließen"
 id = "Tutup"
 it = "Chiudi"
 
 [backtrace]
 en = "Backtrace"
 ru = "Очередь вызовов"
-de = "Backtrace"
 pt = "Backtrace"
+de = "Backtrace"
 id = "Backtrace"
 it = "Backtrace"
 
 [components]
 en = "Components"
 ru = "Компоненты"
+pt = "Componentes"
 de = "Komponenten"
 id = "Komponen"
 it = "Componenti"
-pt = "Componentes"
 
 [settings]
 en = "Settings"
 ru = "Настройки"
-de = "Einstellungen"
 pt = "Configurações"
+de = "Einstellungen"
 id = "Pengaturan"
 it = "Impostazioni"
 
@@ -53,64 +53,64 @@ it = "Impostazioni"
 [creating_default_folders]
 en = "Creating default folders"
 ru = "Создание папок по умолчанию"
-de = "Erstelle Standardordner"
 pt = "Criando diretórios padrão"
+de = "Erstelle Standardordner"
 id = "Membuat folder-folder bawaan"
 it = "Creazione delle cartelle predefinite"
 
 [fetching_packages_allow_lists]
 en = "Fetching packages allow lists"
 ru = "Запрос белых списков пакетов"
-de = "Rufe Paket-Whitelisten auf"
 pt = "Adquirindo listas de permissão do pacote"
+de = "Rufe Paket-Whitelisten auf"
 id = "Mengunduh daftar paket yang diizinkan"
 it = "Recuperando le liste di pacchetti consentiti"
 
 [fetching_games_registries]
 en = "Fetching games registries"
 ru = "Запрос реестров игр"
-de = "Rufe Spielregister auf"
 pt = "Adquirindo registros do jogo"
+de = "Rufe Spielregister auf"
 id = "Mengunduh registrasi game"
 it = "Recuperando i registri dei giochi"
 
 [fetching_games_manifests]
 en = "Fetching games manifests"
 ru = "Запрос информации об играх"
-de = "Rufe Spielmanifste auf"
 pt = "Adquirindo manifestos do jogo"
+de = "Rufe Spielmanifste auf"
 id = "Mengunduh manifest untuk game"
 it = "Recuperando i manifest dei giochi"
 
 [loading_added_games]
 en = "Loading added games"
 ru = "Загрузка добавленных игр"
-de = "Lade hinzugefügte Spiele"
 pt = "Carregando jogos adicionados"
+de = "Lade hinzugefügte Spiele"
 id = "Memuat game ditambahankan"
 it = "Caricamento dei giochi aggiunti"
 
 [loading_game_package]
 en = "Loading {title} game package"
 ru = "Загрузка пакета игры {title}"
-de = "Lade das Spielpaket für {title}"
 pt = "Carregando pacote do jogo {title}"
+de = "Lade das Spielpaket für {title}"
 id = "Memuat paket untuk game {title}"
 it = "Caricando il pacchetto del gioco {title}"
 
 [updating_game_package]
 en = "Updating {title} game package"
 ru = "Обновление пакета игры {title}"
-de = "Aktualisiere das Spielpaket für {title}"
 pt = "Atualizando pacote do jogo {title}"
+de = "Aktualisiere das Spielpaket für {title}"
 id = "Memperbarui paket untuk game {title}"
 it = "Aggiornando il pacchetto del gioco {title}"
 
 [adding_store_page_games]
 en = "Adding store page games"
 ru = "Добавление игр на страницу магазина"
-de = "Füge Spiele der Shopseite hinzu"
 pt = "Adicionando jogos à página da loja"
+de = "Füge Spiele der Shopseite hinzu"
 id = "Menambahkan halaman toko untuk game"
 it = "Aggiunta dei giochi alla pagina del negozio"
 
@@ -119,56 +119,56 @@ it = "Aggiunta dei giochi alla pagina del negozio"
 [loading]
 en = "Loading"
 ru = "Загрузка"
-de = "Lade"
 pt = "Carregando"
+de = "Lade"
 id = "Memuat"
 it = "Caricamento"
 
 [about_launcher]
 en = "About"
 ru = "О программе"
-de = "Über"
 pt = "Sobre"
+de = "Über"
 id = "Tentang"
 it = "Informazioni"
 
 [games_store]
 en = "Store"
 ru = "Магазин"
-de = "Shop"
 pt = "Loja"
+de = "Shop"
 id = "Toko"
 it = "Negozio"
 
 [games_library]
 en = "Library"
 ru = "Библиотека"
-de = "Bibliothek"
 pt = "Biblioteca"
+de = "Bibliothek"
 id = "Perpustakaan"
 it = "Libreria"
 
 [games]
 en = "Games"
 ru = "Игры"
-de = "Spiele"
 pt = "Jogos"
+de = "Spiele"
 id = "Game"
 it = "Giochi"
 
 [details]
 en = "Details"
 ru = "Детали"
-de = "Details"
 pt = "Detalhes"
+de = "Details"
 id = "Detail"
 it = "Dettagli"
 
 [loaded_games_number]
 en = "Loaded {number} games"
 ru = "Загружено {number} игр"
-de = "{number} Spiele geladen"
 pt = "{number} Jogos carregados"
+de = "{number} Spiele geladen"
 id = "Memuat {number} game"
 it = "Caricati {number} giochi"
 
@@ -177,96 +177,96 @@ it = "Caricati {number} giochi"
 [game_agreement_title]
 en = "Game integration agreement"
 ru = "Пользовательское соглашение для установки игры"
+pt = "Acordo da integração de jogo"
 de = "Spielintegrationsvereinbarung"
 id = "Perjanjian untuk pemasangan dan integrasi Gim"
 it = "Accordo per l'integrazione del gioco"
-pt = "Acordo da integração de jogo"
 
 [game_agreement_message]
 en = "<b>{game_title}</b> provides a user agreement. You have to agree with it in order to continue the game integration installation.\n\n{agreement}"
 ru = "<b>{game_title}</b> содержит пользовательское соглашение. Вы должны согласиться с ним для продолжения установки игры.\n\n{agreement}"
+pt = "<b>{game_title}</b> possui um acordo de usuário. Você deve concordar com o acordo para continuar com a instalação da integração de jogo.\n\n{agreement}"
 de = "<b>{game_title}</b> schreibt eine Nutzungsvereinbarung vor. Du musst dieser zustimmen, um fortzufahren.\n\n{agreement}"
 id = "<b>{game_title}</b> memberikan perjanjian pengunaan gim. Anda harus setuju dengan perjanjian tersebut untuk melanjutkan pemasangan inegrasi gim.\n\n{agreement}"
 it = "<b>{game_title}</b> fornisce un accordo utente. Devi accettarlo per continuare l'installazione dell'integrazione del gioco.\n\n{agreement}"
-pt = "<b>{game_title}</b> possui um acordo de usuário. Você deve concordar com o acordo para continuar com a instalação da integração de jogo.\n\n{agreement}"
 
 [game_agreement_agree]
 en = "Agree"
 ru = "Согласен"
+pt = "Concordo"
 de = "Akzeptieren"
 id = "Setuju"
 it = "Accetta"
-pt = "Concordo"
 
 [game_agreement_disagree]
 en = "Disagree"
 ru = "Не согласен"
+pt = "Discordo"
 de = "Ablehnen"
 id = "Tidak Setuju"
 it = "Rifiuta"
-pt = "Discordo"
 
 [game_add_to_library]
 en = "Add to library"
 ru = "Добавить в библиотеку"
-de = "Zur Bibliothek hinzufügen"
 pt = "Adicionar à biblioteca"
+de = "Zur Bibliothek hinzufügen"
 id = "Tambahkan ke perpustakaan"
 it = "Aggiungi alla libreria"
 
 [game_adding_to_library]
 en = "Adding to library..."
 ru = "Добавляем в библиотеку..."
-de = "Füge der Bibliothek hinzu..."
 pt = "Adicionando à biblioteca"
+de = "Füge der Bibliothek hinzu..."
 id = "Menambahkan ke perpustakaan..."
 it = "Aggiunta alla libreria..."
 
 [open_game_in_library]
 en = "Open in library"
 ru = "Открыть в библиотеке"
-de = "In Bibliothek öffnen"
 pt = "Mostrar na biblioteca"
+de = "In Bibliothek öffnen"
 id = "Buka di perpustakaan"
 it = "Apri nella libreria"
 
 [game_developer]
 en = "Developer: {name}"
 ru = "Разработчик: {name}"
-de = "Entwickler: {name}"
 pt = "Desenvolvedor: {name}"
+de = "Entwickler: {name}"
 id = "Pengembang: {game}"
 it = "Sviluppatore: {name}"
 
 [game_publisher]
 en = "Publisher: {name}"
 ru = "Издатель: {name}"
-de = "Publisher: {name}"
 pt = "Publisher: {name}"
+de = "Publisher: {name}"
 id = "Penerbit: {name}"
 it = "Editore: {name}"
 
 [game_package]
 en = "Package"
 ru = "Пакет интеграции"
-de = "Paket"
 pt = "Pacote"
+de = "Paket"
 id = "Paket"
 it = "Pacchetto"
 
 [game_package_maintainers]
 en = "Maintainers"
 ru = "Сопровождающие"
-de = "Maintainer"
 pt = "Mantenedores"
+de = "Maintainer"
 id = "Pengelola"
 it = "Manutentori"
 
 [about_game]
 en = "About game"
 ru = "Об игре"
-de = "Über das Spiel"
 pt = "Sobre o jogo"
+de = "Über das Spiel"
 id = "Tentang game"
 it = "Informazioni sul gioco"
 
@@ -275,56 +275,56 @@ it = "Informazioni sul gioco"
 [no_store_games_available]
 en = "No games available"
 ru = "Нет доступных игр"
+pt = "Nenhum jogo disponível"
 de = "Keine Spiele erhältlich"
 id = "Tidak ada game yang tersedia"
 it = "Nessun gioco disponibile"
-pt = "Nenhum jogo disponível"
 
 [no_library_games_available]
 en = "No games available"
 ru = "Нет доступных игр"
+pt = "Nenhum jogo na biblioteca"
 de = "Keine Spiele erhältlich"
 id = "Tidak ada game yang tersedia"
 it = "Nessun gioco disponibile"
-pt = "Nenhum jogo na biblioteca"
 
 [no_library_game_selected]
 en = "No game selected"
 ru = "Игра не выбрана"
-de = "Kein Spiel ausgewählt"
 pt = "Nenhum jogo selecionado"
+de = "Kein Spiel ausgewählt"
 id = "Tidak ada game dipilih"
 it = "Nessun gioco selezionato"
 
 [game_play]
 en = "Play"
 ru = "Играть"
-de = "Spielen"
 pt = "Jogar"
+de = "Spielen"
 id = "Mulai"
 it = "Gioca"
 
 [game_process_id]
 en = "Game process"
 ru = "Процесс игры"
-de = "Spielprozess"
 pt = "Processo do jogo"
+de = "Spielprozess"
 id = "Proses game"
 it = "Processo di gioco"
 
 [game_running_for]
 en = "Running for"
 ru = "Игра запущена"
-de = "Läuft seit"
 pt = "Executando por"
+de = "Läuft seit"
 id = "Berjalan selama"
 it = "In esecuzione da"
 
 [kill_game_process]
 en = "Kill"
 ru = "Убить"
-de = "Beenden"
 pt = "Matar"
+de = "Beenden"
 id = "Matikan"
 it = "Termina"
 
@@ -333,87 +333,87 @@ it = "Termina"
 [game_components_title]
 en = "Game components"
 ru = "Компоненты игры"
+pt = "Componentes do Jogo"
 de = "Spielkomponenten"
 id = "Komponen Gim"
 it = "Componenti del gioco"
-pt = "Componentes do Jogo"
 
 [game_components_description]
 en = "You can enable or disable different game components. The launcher will suggest applying your changes to the game by installing or uninstalling toggled components. You can also fully uninstall the game using the \"Uninstall all\" button."
 ru = "Вы можете включать и выключать различные компоненты игры. Лаунчер предложит применить ваши изменения игры через установку или удаление выбранных компонентов. Вы также можете полностью удалить игру при нажатии на кнопку \"Удалить всё\"."
+pt = "Você pode habilitar ou desabilitar diferentes componentes de jogo. O launcher permite aplicar mudanças ao jogo instalando ou desinstalando componentes ativos. Você também pode desinstalar o jogo completamente utilizando o botão \"Desinstalar tudo\""
 de = "Du kannst verschiedene Spielkomponenten aktivieren oder deaktivieren. Der Launcher schlägt vor, deine Änderungen am Spiel anzuwenden durch Installation oder Deinstallation von Komponenten. Du kannst auch das Spiel vollständig löschen mit dem \"Alle deinstallieren\" Knopf."
 id = "Anda dapat menyalakan atau mematikan bermacam komponen gim. Peluncur aplikasi akan menyarankan untuk menerapkan perubahan anda kepada gim dengan memasang atau mencopot pemasangan untuk komponen yang dirubah. Anda juga dapat sepenuhnya mencopot gim dengan menggunakan tombol \"Copot semua\""
 it = "Puoi abilitare o disabilitare diversi componenti del gioco. Il launcher proporrà di applicare le modifiche al gioco installando o disinstallando i componenti selezionati. Puoi anche disinstallare completamente il gioco usando il pulsante \"Disinstalla tutto\"."
-pt = "Você pode habilitar ou desabilitar diferentes componentes de jogo. O launcher permite aplicar mudanças ao jogo instalando ou desinstalando componentes ativos. Você também pode desinstalar o jogo completamente utilizando o botão \"Desinstalar tudo\""
 
 [game_components_apply_changes_button_title]
 en = "Apply changes"
 ru = "Применить изменения"
+pt = "Aplicar mudanças"
 de = "Änderungen anwenden"
 id = "Terapkan perubahan"
 it = "Applica modifiche"
-pt = "Aplicar mudanças"
 
 [game_components_uninstall_all_button_title]
 en = "Uninstall all"
 ru = "Удалить всё"
+pt = "Desinstalar tudo"
 de = "Alle deinstallieren"
 id = "Copot semua"
 it = "Disinstalla tutto"
-pt = "Desinstalar tudo"
 
 [game_components_uninstall_all_button_description]
 en = "Uninstall every available component and hide the game from your games library"
 ru = "Удалить все доступные компоненты и скрыть игру из вашей библиотеки игр"
+pt = "Desinstala todos os componentes disponíveis e esconde o jogo da sua biblioteca"
 de = "Deinstalliert alle verfügbaren Komponenten und verberge das Spiel in deiner Bibliothek"
 id = "Copot semua komponen tersedia dan semunyikan gim dari daftar gim anda"
 it = "Disinstalla tutti i componenti presenti e nascondi il gioco dalla tua libreria"
-pt = "Desinstala todos os componentes disponíveis e esconde o jogo da sua biblioteca"
 
 [game_components_uninstall_all_approve_dialog_title]
 en = "Uninstall all game components?"
 ru = "Удалить все компоненты игры?"
+pt = "Desinstalaer todos os componentes do jogo?"
 de = "Alle Spielkomponenten deinstallieren?"
 id = "Copot semua komponen gim?"
 it = "Disinstallare tutti i componenti del gioco?"
-pt = "Desinstalaer todos os componentes do jogo?"
 
 [game_components_uninstall_all_approve_dialog_message]
 en = "This action will uninstall every game component and delete the game from your library. After agreeing you will not be able to restore the game without reinstalling it from the games store page. Do you want to continue?"
 ru = "Это действие удалит все компоненты игры, а также саму игру из вашей библиотеки. При согласии вы не сможете восстановить игру без полной её переустановки через страницу магазина игр. Вы хотите продолжить?"
+pt = "Essa ação irá desinstalar todos os componentes do jogo e apagar o jogo de sua biblioteca. Após concordar, você não poderá restaurar o jogo sem reinstala-lo pela página da loja. Deseja continuar?"
 de = "Diese Aktion wird alle Spielkomponenten deinstallieren und dieses Spiel aus deiner Bibliothek löschen. Du wirst das Spiel nicht mehr wiederherstellen können ohne über den Shop wieder zu installieren. Möchtest du fortfahren?"
 id = "Aksi ini akan mencopot semua komponen gim dan menghapus gim dari daftar gim anda. Setelah menyetujui anda tidak akan dapat mengembalikan gim tanpa menmasang ulang dari halaman toko gim. Apa anda ingin melanjutkan?"
 it = "Questa azione disinstallerà tutti i componenti del gioco e lo eliminerà dalla tua libreria. Dopo aver accettato, non potrai ripristinare il gioco senza reinstallarlo dalla pagina del negozio. Vuoi continuare?"
-pt = "Essa ação irá desinstalar todos os componentes do jogo e apagar o jogo de sua biblioteca. Após concordar, você não poderá restaurar o jogo sem reinstala-lo pela página da loja. Deseja continuar?"
 
 [game_components_apply_changes_title]
 en = "Apply components changes"
 ru = "Применение изменений компонентов"
+pt = "Aplicar mudanças de componentes"
 de = "Komponentenänderungen anwenden"
 id = "Terapkan perubahan komponen"
 it = "Applica modifiche ai componenti"
-pt = "Aplicar mudanças de componentes"
 
 [game_components_uninstall_all_title]
 en = "Uninstall game components"
 ru = "Удаление компонентов игры"
+pt = "Desinstalar componentes de jogo"
 de = "Spielkomponenten deinstallieren"
 id = "Copot komponen gim"
 it = "Disinstalla componenti del gioco"
-pt = "Desinstalar componentes de jogo"
 
 [game_component_install_title]
 en = "Install {component}"
 ru = "Установка {component}"
+pt = "Instalar {component}"
 de = "{component} installieren"
 id = "Pasang {component}"
 it = "Installa {component}"
-pt = "Instalar {component}"
 
 [game_component_uninstall_title]
 en = "Uninstall {component}"
 ru = "Удаление {component}"
+pt = "Desinstalar {component}"
 de = "{component} deinstallieren"
 id = "Copot {component}"
 it = "Disinstalla {component}"
-pt = "Desinstalar {component}"

--- a/crates/anime-games-launcher/assets/locales/interface.toml
+++ b/crates/anime-games-launcher/assets/locales/interface.toml
@@ -7,6 +7,7 @@ pt = "Continuar"
 de = "Fortfahren"
 id = "Lanjut"
 it = "Continua"
+ja = "続行"
 
 [cancel]
 en = "Cancel"
@@ -15,6 +16,7 @@ pt = "Cancelar"
 de = "Abbrechen"
 id = "Batal"
 it = "Annulla"
+ja = "キャンセル"
 
 [close]
 en = "Close"
@@ -23,6 +25,7 @@ pt = "Fechar"
 de = "Schließen"
 id = "Tutup"
 it = "Chiudi"
+ja = "閉じる"
 
 [backtrace]
 en = "Backtrace"
@@ -31,6 +34,7 @@ pt = "Backtrace"
 de = "Backtrace"
 id = "Backtrace"
 it = "Backtrace"
+ja = "バックトレース"
 
 [components]
 en = "Components"
@@ -39,6 +43,7 @@ pt = "Componentes"
 de = "Komponenten"
 id = "Komponen"
 it = "Componenti"
+ja = "コンポーネント"
 
 [settings]
 en = "Settings"
@@ -47,6 +52,7 @@ pt = "Configurações"
 de = "Einstellungen"
 id = "Pengaturan"
 it = "Impostazioni"
+ja = "設定"
 
 # ------------------------ Startup tasks ------------------------
 
@@ -57,6 +63,7 @@ pt = "Criando diretórios padrão"
 de = "Erstelle Standardordner"
 id = "Membuat folder-folder bawaan"
 it = "Creazione delle cartelle predefinite"
+ja = "デフォルトのフォルダを作成しています"
 
 [fetching_packages_allow_lists]
 en = "Fetching packages allow lists"
@@ -97,6 +104,7 @@ pt = "Carregando pacote do jogo {title}"
 de = "Lade das Spielpaket für {title}"
 id = "Memuat paket untuk game {title}"
 it = "Caricando il pacchetto del gioco {title}"
+ja = "{title} ゲームパッケージを読み込んでいます"
 
 [updating_game_package]
 en = "Updating {title} game package"
@@ -105,6 +113,7 @@ pt = "Atualizando pacote do jogo {title}"
 de = "Aktualisiere das Spielpaket für {title}"
 id = "Memperbarui paket untuk game {title}"
 it = "Aggiornando il pacchetto del gioco {title}"
+ja = "{title} ゲームパッケージを更新しています"
 
 [adding_store_page_games]
 en = "Adding store page games"
@@ -123,6 +132,7 @@ pt = "Carregando"
 de = "Lade"
 id = "Memuat"
 it = "Caricamento"
+ja = "ロード中"
 
 [about_launcher]
 en = "About"
@@ -131,6 +141,7 @@ pt = "Sobre"
 de = "Über"
 id = "Tentang"
 it = "Informazioni"
+ja = "このランチャーについて"
 
 [games_store]
 en = "Store"
@@ -139,6 +150,7 @@ pt = "Loja"
 de = "Shop"
 id = "Toko"
 it = "Negozio"
+ja = "ストア"
 
 [games_library]
 en = "Library"
@@ -147,6 +159,7 @@ pt = "Biblioteca"
 de = "Bibliothek"
 id = "Perpustakaan"
 it = "Libreria"
+ja = "ライブラリ"
 
 [games]
 en = "Games"
@@ -163,6 +176,7 @@ pt = "Detalhes"
 de = "Details"
 id = "Detail"
 it = "Dettagli"
+ja = "詳細"
 
 [loaded_games_number]
 en = "Loaded {number} games"
@@ -171,6 +185,7 @@ pt = "{number} Jogos carregados"
 de = "{number} Spiele geladen"
 id = "Memuat {number} game"
 it = "Caricati {number} giochi"
+ja = "{number} つのゲームを読み込みました"
 
 # ------------------------ Game store page ------------------------
 
@@ -181,6 +196,7 @@ pt = "Acordo da integração de jogo"
 de = "Spielintegrationsvereinbarung"
 id = "Perjanjian untuk pemasangan dan integrasi Gim"
 it = "Accordo per l'integrazione del gioco"
+ja = "ゲーム統合の確認"
 
 [game_agreement_message]
 en = "<b>{game_title}</b> provides a user agreement. You have to agree with it in order to continue the game integration installation.\n\n{agreement}"
@@ -197,6 +213,7 @@ pt = "Concordo"
 de = "Akzeptieren"
 id = "Setuju"
 it = "Accetta"
+ja = "同意"
 
 [game_agreement_disagree]
 en = "Disagree"
@@ -205,6 +222,7 @@ pt = "Discordo"
 de = "Ablehnen"
 id = "Tidak Setuju"
 it = "Rifiuta"
+ja = "同意しない"
 
 [game_add_to_library]
 en = "Add to library"
@@ -213,6 +231,7 @@ pt = "Adicionar à biblioteca"
 de = "Zur Bibliothek hinzufügen"
 id = "Tambahkan ke perpustakaan"
 it = "Aggiungi alla libreria"
+ja = "ライブラリに追加"
 
 [game_adding_to_library]
 en = "Adding to library..."
@@ -221,6 +240,7 @@ pt = "Adicionando à biblioteca"
 de = "Füge der Bibliothek hinzu..."
 id = "Menambahkan ke perpustakaan..."
 it = "Aggiunta alla libreria..."
+ja = "ライブラリに追加しています..."
 
 [open_game_in_library]
 en = "Open in library"
@@ -229,6 +249,7 @@ pt = "Mostrar na biblioteca"
 de = "In Bibliothek öffnen"
 id = "Buka di perpustakaan"
 it = "Apri nella libreria"
+ja = "ライブラリで開く"
 
 [game_developer]
 en = "Developer: {name}"
@@ -237,6 +258,7 @@ pt = "Desenvolvedor: {name}"
 de = "Entwickler: {name}"
 id = "Pengembang: {game}"
 it = "Sviluppatore: {name}"
+ja = "開発元: {name}"
 
 [game_publisher]
 en = "Publisher: {name}"
@@ -245,6 +267,7 @@ pt = "Publisher: {name}"
 de = "Publisher: {name}"
 id = "Penerbit: {name}"
 it = "Editore: {name}"
+ja = "パブリッシャー: {name}"
 
 [game_package]
 en = "Package"
@@ -253,6 +276,7 @@ pt = "Pacote"
 de = "Paket"
 id = "Paket"
 it = "Pacchetto"
+ja = "パッケージ"
 
 [game_package_maintainers]
 en = "Maintainers"
@@ -261,6 +285,7 @@ pt = "Mantenedores"
 de = "Maintainer"
 id = "Pengelola"
 it = "Manutentori"
+ja = "メンテナ"
 
 [about_game]
 en = "About game"
@@ -269,6 +294,7 @@ pt = "Sobre o jogo"
 de = "Über das Spiel"
 id = "Tentang game"
 it = "Informazioni sul gioco"
+ja = "このゲームについて"
 
 # ------------------------ Game library page ------------------------
 
@@ -279,6 +305,7 @@ pt = "Nenhum jogo disponível"
 de = "Keine Spiele erhältlich"
 id = "Tidak ada game yang tersedia"
 it = "Nessun gioco disponibile"
+ja = "ゲームがありません"
 
 [no_library_games_available]
 en = "No games available"
@@ -287,6 +314,7 @@ pt = "Nenhum jogo na biblioteca"
 de = "Keine Spiele erhältlich"
 id = "Tidak ada game yang tersedia"
 it = "Nessun gioco disponibile"
+ja = "ゲームがありません"
 
 [no_library_game_selected]
 en = "No game selected"
@@ -295,6 +323,7 @@ pt = "Nenhum jogo selecionado"
 de = "Kein Spiel ausgewählt"
 id = "Tidak ada game dipilih"
 it = "Nessun gioco selezionato"
+ja = "ゲームが選択されていません"
 
 [game_play]
 en = "Play"
@@ -303,6 +332,7 @@ pt = "Jogar"
 de = "Spielen"
 id = "Mulai"
 it = "Gioca"
+ja = "プレイ"
 
 [game_process_id]
 en = "Game process"
@@ -311,6 +341,7 @@ pt = "Processo do jogo"
 de = "Spielprozess"
 id = "Proses game"
 it = "Processo di gioco"
+ja = "ゲームプロセス"
 
 [game_running_for]
 en = "Running for"
@@ -319,6 +350,7 @@ pt = "Executando por"
 de = "Läuft seit"
 id = "Berjalan selama"
 it = "In esecuzione da"
+ja = "稼働時間"
 
 [kill_game_process]
 en = "Kill"
@@ -327,6 +359,7 @@ pt = "Matar"
 de = "Beenden"
 id = "Matikan"
 it = "Termina"
+ja = "強制終了"
 
 # ------------------------ Game components window ------------------------
 
@@ -337,6 +370,7 @@ pt = "Componentes do Jogo"
 de = "Spielkomponenten"
 id = "Komponen Gim"
 it = "Componenti del gioco"
+ja = "ゲームコンポーネント"
 
 [game_components_description]
 en = "You can enable or disable different game components. The launcher will suggest applying your changes to the game by installing or uninstalling toggled components. You can also fully uninstall the game using the \"Uninstall all\" button."
@@ -345,6 +379,7 @@ pt = "Você pode habilitar ou desabilitar diferentes componentes de jogo. O laun
 de = "Du kannst verschiedene Spielkomponenten aktivieren oder deaktivieren. Der Launcher schlägt vor, deine Änderungen am Spiel anzuwenden durch Installation oder Deinstallation von Komponenten. Du kannst auch das Spiel vollständig löschen mit dem \"Alle deinstallieren\" Knopf."
 id = "Anda dapat menyalakan atau mematikan bermacam komponen gim. Peluncur aplikasi akan menyarankan untuk menerapkan perubahan anda kepada gim dengan memasang atau mencopot pemasangan untuk komponen yang dirubah. Anda juga dapat sepenuhnya mencopot gim dengan menggunakan tombol \"Copot semua\""
 it = "Puoi abilitare o disabilitare diversi componenti del gioco. Il launcher proporrà di applicare le modifiche al gioco installando o disinstallando i componenti selezionati. Puoi anche disinstallare completamente il gioco usando il pulsante \"Disinstalla tutto\"."
+ja = "ここでゲームの各種コンポーネントを有効または無効にすることができます。ランチャーは、選択されたコンポーネントをインストールまたはアンインストールすることで、ゲームに変更を適用するかどうかを尋ねます。「全てのコンポーネントを削除する」ボタンを使用してゲームを完全にアンインストールすることもできます。"
 
 [game_components_apply_changes_button_title]
 en = "Apply changes"
@@ -353,6 +388,7 @@ pt = "Aplicar mudanças"
 de = "Änderungen anwenden"
 id = "Terapkan perubahan"
 it = "Applica modifiche"
+ja = "変更を適用"
 
 [game_components_uninstall_all_button_title]
 en = "Uninstall all"
@@ -361,6 +397,7 @@ pt = "Desinstalar tudo"
 de = "Alle deinstallieren"
 id = "Copot semua"
 it = "Disinstalla tutto"
+ja = "全てのコンポーネントを削除する"
 
 [game_components_uninstall_all_button_description]
 en = "Uninstall every available component and hide the game from your games library"
@@ -369,6 +406,7 @@ pt = "Desinstala todos os componentes disponíveis e esconde o jogo da sua bibli
 de = "Deinstalliert alle verfügbaren Komponenten und verberge das Spiel in deiner Bibliothek"
 id = "Copot semua komponen tersedia dan semunyikan gim dari daftar gim anda"
 it = "Disinstalla tutti i componenti presenti e nascondi il gioco dalla tua libreria"
+ja = "全てのコンポーネントを削除し、ゲームライブラリからゲームを削除します。"
 
 [game_components_uninstall_all_approve_dialog_title]
 en = "Uninstall all game components?"
@@ -377,6 +415,7 @@ pt = "Desinstalaer todos os componentes do jogo?"
 de = "Alle Spielkomponenten deinstallieren?"
 id = "Copot semua komponen gim?"
 it = "Disinstallare tutti i componenti del gioco?"
+ja = "全てのゲームコンポーネントを削除しますか？"
 
 [game_components_uninstall_all_approve_dialog_message]
 en = "This action will uninstall every game component and delete the game from your library. After agreeing you will not be able to restore the game without reinstalling it from the games store page. Do you want to continue?"
@@ -385,6 +424,7 @@ pt = "Essa ação irá desinstalar todos os componentes do jogo e apagar o jogo 
 de = "Diese Aktion wird alle Spielkomponenten deinstallieren und dieses Spiel aus deiner Bibliothek löschen. Du wirst das Spiel nicht mehr wiederherstellen können ohne über den Shop wieder zu installieren. Möchtest du fortfahren?"
 id = "Aksi ini akan mencopot semua komponen gim dan menghapus gim dari daftar gim anda. Setelah menyetujui anda tidak akan dapat mengembalikan gim tanpa menmasang ulang dari halaman toko gim. Apa anda ingin melanjutkan?"
 it = "Questa azione disinstallerà tutti i componenti del gioco e lo eliminerà dalla tua libreria. Dopo aver accettato, non potrai ripristinare il gioco senza reinstallarlo dalla pagina del negozio. Vuoi continuare?"
+ja = "この操作は全てのコンポーネントを削除し、ライブラリからゲームを削除します。ストアページからゲームを再インストールするまで、ゲームを再度プレイすることはできなくなります。続行しますか？"
 
 [game_components_apply_changes_title]
 en = "Apply components changes"
@@ -393,6 +433,7 @@ pt = "Aplicar mudanças de componentes"
 de = "Komponentenänderungen anwenden"
 id = "Terapkan perubahan komponen"
 it = "Applica modifiche ai componenti"
+ja = "コンポーネントの変更を適用"
 
 [game_components_uninstall_all_title]
 en = "Uninstall game components"
@@ -401,6 +442,7 @@ pt = "Desinstalar componentes de jogo"
 de = "Spielkomponenten deinstallieren"
 id = "Copot komponen gim"
 it = "Disinstalla componenti del gioco"
+ja = "ゲームコンポーネントを削除"
 
 [game_component_install_title]
 en = "Install {component}"
@@ -409,6 +451,7 @@ pt = "Instalar {component}"
 de = "{component} installieren"
 id = "Pasang {component}"
 it = "Installa {component}"
+ja = "{component} のインストール"
 
 [game_component_uninstall_title]
 en = "Uninstall {component}"
@@ -417,3 +460,4 @@ pt = "Desinstalar {component}"
 de = "{component} deinstallieren"
 id = "Copot {component}"
 it = "Disinstalla {component}"
+ja = "{component} のアンインストール"

--- a/crates/anime-games-launcher/assets/locales/interface.toml
+++ b/crates/anime-games-launcher/assets/locales/interface.toml
@@ -336,6 +336,7 @@ ru = "Компоненты игры"
 de = "Spielkomponenten"
 id = "Komponen Gim"
 it = "Componenti del gioco"
+pt = "Componentes do Jogo"
 
 [game_components_description]
 en = "You can enable or disable different game components. The launcher will suggest applying your changes to the game by installing or uninstalling toggled components. You can also fully uninstall the game using the \"Uninstall all\" button."
@@ -343,6 +344,7 @@ ru = "Вы можете включать и выключать различны�
 de = "Du kannst verschiedene Spielkomponenten aktivieren oder deaktivieren. Der Launcher schlägt vor, deine Änderungen am Spiel anzuwenden durch Installation oder Deinstallation von Komponenten. Du kannst auch das Spiel vollständig löschen mit dem \"Alle deinstallieren\" Knopf."
 id = "Anda dapat menyalakan atau mematikan bermacam komponen gim. Peluncur aplikasi akan menyarankan untuk menerapkan perubahan anda kepada gim dengan memasang atau mencopot pemasangan untuk komponen yang dirubah. Anda juga dapat sepenuhnya mencopot gim dengan menggunakan tombol \"Copot semua\""
 it = "Puoi abilitare o disabilitare diversi componenti del gioco. Il launcher proporrà di applicare le modifiche al gioco installando o disinstallando i componenti selezionati. Puoi anche disinstallare completamente il gioco usando il pulsante \"Disinstalla tutto\"."
+pt = "Você pode habilitar ou desabilitar diferentes componentes de jogo. O launcher permite aplicar mudanças ao jogo instalando ou desinstalando componentes ativos. Você também pode desinstalar o jogo completamente utilizando o botão \"Desinstalar tudo\""
 
 [game_components_apply_changes_button_title]
 en = "Apply changes"
@@ -350,6 +352,7 @@ ru = "Применить изменения"
 de = "Änderungen anwenden"
 id = "Terapkan perubahan"
 it = "Applica modifiche"
+pt = "Aplicar mudanças"
 
 [game_components_uninstall_all_button_title]
 en = "Uninstall all"
@@ -357,6 +360,7 @@ ru = "Удалить всё"
 de = "Alle deinstallieren"
 id = "Copot semua"
 it = "Disinstalla tutto"
+pt = "Desinstalar tudo"
 
 [game_components_uninstall_all_button_description]
 en = "Uninstall every available component and hide the game from your games library"
@@ -364,6 +368,7 @@ ru = "Удалить все доступные компоненты и скры�
 de = "Deinstalliert alle verfügbaren Komponenten und verberge das Spiel in deiner Bibliothek"
 id = "Copot semua komponen tersedia dan semunyikan gim dari daftar gim anda"
 it = "Disinstalla tutti i componenti presenti e nascondi il gioco dalla tua libreria"
+pt = "Desinstala todos os componentes disponíveis e esconde o jogo da sua biblioteca"
 
 [game_components_uninstall_all_approve_dialog_title]
 en = "Uninstall all game components?"
@@ -371,6 +376,7 @@ ru = "Удалить все компоненты игры?"
 de = "Alle Spielkomponenten deinstallieren?"
 id = "Copot semua komponen gim?"
 it = "Disinstallare tutti i componenti del gioco?"
+pt = "Desinstalaer todos os componentes do jogo?"
 
 [game_components_uninstall_all_approve_dialog_message]
 en = "This action will uninstall every game component and delete the game from your library. After agreeing you will not be able to restore the game without reinstalling it from the games store page. Do you want to continue?"
@@ -378,6 +384,7 @@ ru = "Это действие удалит все компоненты игры,
 de = "Diese Aktion wird alle Spielkomponenten deinstallieren und dieses Spiel aus deiner Bibliothek löschen. Du wirst das Spiel nicht mehr wiederherstellen können ohne über den Shop wieder zu installieren. Möchtest du fortfahren?"
 id = "Aksi ini akan mencopot semua komponen gim dan menghapus gim dari daftar gim anda. Setelah menyetujui anda tidak akan dapat mengembalikan gim tanpa menmasang ulang dari halaman toko gim. Apa anda ingin melanjutkan?"
 it = "Questa azione disinstallerà tutti i componenti del gioco e lo eliminerà dalla tua libreria. Dopo aver accettato, non potrai ripristinare il gioco senza reinstallarlo dalla pagina del negozio. Vuoi continuare?"
+pt = "Essa ação irá desinstalar todos os componentes do jogo e apagar o jogo de sua biblioteca. Após concordar, você não poderá restaurar o jogo sem reinstala-lo pela página da loja. Deseja continuar?"
 
 [game_components_apply_changes_title]
 en = "Apply components changes"
@@ -385,6 +392,7 @@ ru = "Применение изменений компонентов"
 de = "Komponentenänderungen anwenden"
 id = "Terapkan perubahan komponen"
 it = "Applica modifiche ai componenti"
+pt = "Aplicar mudanças de componentes"
 
 [game_components_uninstall_all_title]
 en = "Uninstall game components"
@@ -392,6 +400,7 @@ ru = "Удаление компонентов игры"
 de = "Spielkomponenten deinstallieren"
 id = "Copot komponen gim"
 it = "Disinstalla componenti del gioco"
+pt = "Desinstalar componentes de jogo"
 
 [game_component_install_title]
 en = "Install {component}"
@@ -399,6 +408,7 @@ ru = "Установка {component}"
 de = "{component} installieren"
 id = "Pasang {component}"
 it = "Installa {component}"
+pt = "Instalar {component}"
 
 [game_component_uninstall_title]
 en = "Uninstall {component}"
@@ -406,3 +416,4 @@ ru = "Удаление {component}"
 de = "{component} deinstallieren"
 id = "Copot {component}"
 it = "Disinstalla {component}"
+pt = "Desinstalar {component}"

--- a/crates/anime-games-launcher/assets/locales/interface.toml
+++ b/crates/anime-games-launcher/assets/locales/interface.toml
@@ -115,6 +115,10 @@ id = "Memperbarui paket untuk game {title}"
 it = "Aggiornando il pacchetto del gioco {title}"
 ja = "{title} ゲームパッケージを更新しています"
 
+[collecting_garbage]
+en = "Collecting garbage"
+ru = "Сбор мусора"
+
 [adding_store_page_games]
 en = "Adding store page games"
 ru = "Добавление игр на страницу магазина"

--- a/crates/anime-games-launcher/assets/locales/interface.toml
+++ b/crates/anime-games-launcher/assets/locales/interface.toml
@@ -314,6 +314,7 @@ it = "Processo di gioco"
 
 [game_running_for]
 en = "Running for"
+ru = "Игра запущена"
 de = "Läuft seit"
 pt = "Executando por"
 id = "Berjalan selama"

--- a/crates/anime-games-launcher/assets/locales/interface.toml
+++ b/crates/anime-games-launcher/assets/locales/interface.toml
@@ -89,6 +89,10 @@ de = "Rufe Spielmanifste auf"
 id = "Mengunduh manifest untuk game"
 it = "Recuperando i manifest dei giochi"
 
+[clearing_cache]
+en = "Clearing cache"
+ru = "Очистка кэша"
+
 [loading_added_games]
 en = "Loading added games"
 ru = "Загрузка добавленных игр"

--- a/crates/anime-games-launcher/assets/locales/interface.toml
+++ b/crates/anime-games-launcher/assets/locales/interface.toml
@@ -6,6 +6,7 @@ ru = "Продолжить"
 de = "Fortfahren"
 id = "Lanjut"
 it = "Continua"
+pt = "Continuar"
 
 [cancel]
 en = "Cancel"
@@ -13,6 +14,7 @@ ru = "Отменить"
 de = "Abbrechen"
 id = "Batal"
 it = "Annulla"
+pt = "Cancelar"
 
 [close]
 en = "Close"
@@ -36,6 +38,7 @@ ru = "Компоненты"
 de = "Komponenten"
 id = "Komponen"
 it = "Componenti"
+pt = "Componentes"
 
 [settings]
 en = "Settings"
@@ -177,6 +180,7 @@ ru = "Пользовательское соглашение для устано�
 de = "Spielintegrationsvereinbarung"
 id = "Perjanjian untuk pemasangan dan integrasi Gim"
 it = "Accordo per l'integrazione del gioco"
+pt = "Acordo da integração de jogo"
 
 [game_agreement_message]
 en = "<b>{game_title}</b> provides a user agreement. You have to agree with it in order to continue the game integration installation.\n\n{agreement}"
@@ -184,6 +188,7 @@ ru = "<b>{game_title}</b> содержит пользовательское со
 de = "<b>{game_title}</b> schreibt eine Nutzungsvereinbarung vor. Du musst dieser zustimmen, um fortzufahren.\n\n{agreement}"
 id = "<b>{game_title}</b> memberikan perjanjian pengunaan gim. Anda harus setuju dengan perjanjian tersebut untuk melanjutkan pemasangan inegrasi gim.\n\n{agreement}"
 it = "<b>{game_title}</b> fornisce un accordo utente. Devi accettarlo per continuare l'installazione dell'integrazione del gioco.\n\n{agreement}"
+pt = "<b>{game_title}</b> possui um acordo de usuário. Você deve concordar com o acordo para continuar com a instalação da integração de jogo.\n\n{agreement}"
 
 [game_agreement_agree]
 en = "Agree"
@@ -191,6 +196,7 @@ ru = "Согласен"
 de = "Akzeptieren"
 id = "Setuju"
 it = "Accetta"
+pt = "Concordo"
 
 [game_agreement_disagree]
 en = "Disagree"
@@ -198,6 +204,7 @@ ru = "Не согласен"
 de = "Ablehnen"
 id = "Tidak Setuju"
 it = "Rifiuta"
+pt = "Discordo"
 
 [game_add_to_library]
 en = "Add to library"
@@ -271,6 +278,7 @@ ru = "Нет доступных игр"
 de = "Keine Spiele erhältlich"
 id = "Tidak ada game yang tersedia"
 it = "Nessun gioco disponibile"
+pt = "Nenhum jogo disponível"
 
 [no_library_games_available]
 en = "No games available"
@@ -278,6 +286,7 @@ ru = "Нет доступных игр"
 de = "Keine Spiele erhältlich"
 id = "Tidak ada game yang tersedia"
 it = "Nessun gioco disponibile"
+pt = "Nenhum jogo na biblioteca"
 
 [no_library_game_selected]
 en = "No game selected"

--- a/crates/anime-games-launcher/src/cache.rs
+++ b/crates/anime-games-launcher/src/cache.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // anime-games-launcher
-// Copyright (C) 2025  Nikita Podvirnyi <krypt0nn@vk.com>
+// Copyright (C) 2025 - 2026  Nikita Podvirnyi <krypt0nn@vk.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -31,23 +31,23 @@ pub fn get_path(key: impl AsRef<[u8]>) -> PathBuf {
     CACHE_FOLDER.join(Hash::from_bytes(key.as_ref()).to_base32())
 }
 
-/// Check if a file with provided path is expired. Return `Ok(true)` if such
-/// file doesn't exist.
-pub fn is_expired(
-    path: impl AsRef<Path>,
-    ttl: Duration
-) -> anyhow::Result<bool> {
-    let path = path.as_ref();
-
+/// Check if a file with provided path is expired.
+///
+/// Return `Ok(true)` if the file doesn't exist or file system doesn't support
+/// modification and creation timestamps.
+pub async fn is_expired(path: &Path, ttl: Duration) -> anyhow::Result<bool> {
     if !path.exists() {
         return Ok(true);
     }
 
-    let metadata = path.metadata()
+    let metadata = agl_core::tasks::fs::metadata(path).await
         .context("failed to read cached file metadata")?;
 
-    let created_at = metadata.created()
-        .context("failed to read cached file creation time")?;
-
-    Ok(created_at.elapsed()? > ttl)
+    match metadata.modified() {
+        Ok(modified_at) => Ok(modified_at.elapsed()? > ttl),
+        Err(_) => match metadata.created() {
+            Ok(created_at) => Ok(created_at.elapsed()? > ttl),
+            Err(_) => Ok(true)
+        }
+    }
 }

--- a/crates/anime-games-launcher/src/cache.rs
+++ b/crates/anime-games-launcher/src/cache.rs
@@ -23,12 +23,12 @@ use anyhow::Context;
 
 use agl_packages::hash::Hash;
 
-use crate::consts::CACHE_FOLDER;
+use crate::consts::CACHE_DIR;
 
 /// Get path to a file with provided cache key.
 #[inline]
 pub fn get_path(key: impl AsRef<[u8]>) -> PathBuf {
-    CACHE_FOLDER.join(Hash::from_bytes(key.as_ref()).to_base32())
+    CACHE_DIR.join(Hash::from_bytes(key.as_ref()).to_base32())
 }
 
 /// Check if a file with provided path is expired.
@@ -43,11 +43,8 @@ pub async fn is_expired(path: &Path, ttl: Duration) -> anyhow::Result<bool> {
     let metadata = agl_core::tasks::fs::metadata(path).await
         .context("failed to read cached file metadata")?;
 
-    match metadata.modified() {
-        Ok(modified_at) => Ok(modified_at.elapsed()? > ttl),
-        Err(_) => match metadata.created() {
-            Ok(created_at) => Ok(created_at.elapsed()? > ttl),
-            Err(_) => Ok(true)
-        }
+    match metadata.modified().or_else(|_| metadata.created()) {
+        Ok(timestamp) => Ok(timestamp.elapsed()? > ttl),
+        Err(_) => Ok(true)
     }
 }

--- a/crates/anime-games-launcher/src/config.rs
+++ b/crates/anime-games-launcher/src/config.rs
@@ -26,7 +26,7 @@ use agl_core::export::network::reqwest;
 use agl_core::tasks;
 use agl_locale::unic_langid::LanguageIdentifier;
 
-use crate::consts::{DATA_FOLDER, CONFIG_FILE};
+use crate::consts::{DATA_DIR, CONFIG_FILE};
 
 lazy_static::lazy_static! {
     static ref STARTUP_CONFIG: Config = tasks::block_on(get());
@@ -79,6 +79,12 @@ pub struct Config {
     ///
     /// `cache.packages_allow_lists.duration`
     pub cache_packages_allow_lists_duration: Duration,
+
+    /// Duration since cache entry creation after which it will be automatically
+    /// removed.
+    ///
+    /// `cache.collect_garbage_after`
+    pub cache_collect_garbage_after: Duration,
 
     /// URLs to the modules allow lists files.
     ///
@@ -186,20 +192,21 @@ impl Default for Config {
             cache_game_manifests_duration: Duration::from_hours(24),
             cache_game_packages_duration: Duration::from_hours(8),
             cache_packages_allow_lists_duration: Duration::from_hours(8),
+            cache_collect_garbage_after: Duration::from_hours(72),
 
             packages_allow_lists: vec![
                 String::from("https://raw.githubusercontent.com/an-anime-team/game-integrations/refs/heads/master/packages/allow_list.json")
             ],
 
-            packages_resources_path: DATA_FOLDER.join("packages").join("resources"),
+            packages_resources_path: DATA_DIR.join("packages").join("resources"),
             packages_resources_collect_garbage: true,
 
-            packages_modules_path: DATA_FOLDER.join("packages").join("modules"),
+            packages_modules_path: DATA_DIR.join("packages").join("modules"),
             packages_modules_collect_garbage: true,
 
-            packages_persistent_path: DATA_FOLDER.join("packages").join("persistent"),
+            packages_persistent_path: DATA_DIR.join("packages").join("persistent"),
 
-            packages_temporary_path: DATA_FOLDER.join("packages").join("temporary"),
+            packages_temporary_path: DATA_DIR.join("packages").join("temporary"),
             packages_temporary_collect_garbage: true,
 
             runtime_memory_limit: 1024 * 1024 * 1024,
@@ -213,7 +220,7 @@ impl Default for Config {
             games_registries: vec![
                 String::from("https://raw.githubusercontent.com/an-anime-team/game-integrations/refs/heads/master/games/registry.json")
             ],
-            games_path: DATA_FOLDER.join("games")
+            games_path: DATA_DIR.join("games")
         }
     }
 }
@@ -227,6 +234,9 @@ impl Config {
             [general.network]
             timeout = (self.general_network_timeout.as_millis() as u64)
             proxy = (self.general_network_proxy.as_deref().unwrap_or("system"))
+
+            [cache]
+            collect_garbage_after = (self.cache_collect_garbage_after.as_secs())
 
             [cache.images]
             duration = (self.cache_images_duration.as_secs())
@@ -365,6 +375,11 @@ impl Config {
                 if let Some(duration) = packages_allow_lists.get("duration").and_then(Toml::as_integer) {
                     config.cache_packages_allow_lists_duration = Duration::from_secs(duration as u64);
                 }
+            }
+
+            // `cache.collect_garbage_after`
+            if let Some(collect_garbage_after) = cache.get("collect_garbage_after").and_then(Toml::as_integer) {
+                config.cache_collect_garbage_after = Duration::from_secs(collect_garbage_after as u64);
             }
         }
 

--- a/crates/anime-games-launcher/src/config.rs
+++ b/crates/anime-games-launcher/src/config.rs
@@ -28,7 +28,7 @@ use agl_locale::unic_langid::LanguageIdentifier;
 use crate::consts::{DATA_FOLDER, CONFIG_FILE};
 
 lazy_static::lazy_static! {
-    static ref STARTUP_CONFIG: Config = get();
+    static ref STARTUP_CONFIG: Config = agl_core::tasks::block_on(get());
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -499,19 +499,19 @@ pub fn startup() -> &'static Config {
 }
 
 /// Read configuration from the file.
-pub fn get() -> Config {
-    std::fs::read(CONFIG_FILE.as_path()).ok()
+pub async fn get() -> Config {
+    agl_core::tasks::fs::read(CONFIG_FILE.as_path()).await.ok()
         .and_then(|config| toml::from_slice::<TomlTable>(&config).ok())
         .map(|config| Config::from_toml(&config))
         .unwrap_or_default()
 }
 
 /// Update configuration file.
-pub fn set(config: &Config) -> anyhow::Result<()> {
-    std::fs::write(
+pub async fn set(config: &Config) -> anyhow::Result<()> {
+    agl_core::tasks::fs::write(
         CONFIG_FILE.as_path(),
         toml::to_string_pretty(&config.to_toml())?
-    )?;
+    ).await?;
 
     Ok(())
 }

--- a/crates/anime-games-launcher/src/config.rs
+++ b/crates/anime-games-launcher/src/config.rs
@@ -23,12 +23,13 @@ use anyhow::Context;
 use toml::{toml, Value as Toml, Table as TomlTable};
 
 use agl_core::export::network::reqwest;
+use agl_core::tasks;
 use agl_locale::unic_langid::LanguageIdentifier;
 
 use crate::consts::{DATA_FOLDER, CONFIG_FILE};
 
 lazy_static::lazy_static! {
-    static ref STARTUP_CONFIG: Config = agl_core::tasks::block_on(get());
+    static ref STARTUP_CONFIG: Config = tasks::block_on(get());
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -46,8 +47,8 @@ pub struct Config {
     /// Proxy URL. If unset (`system`) - environment variable proxy is used
     /// (`http_proxy`, `https_proxy`, `all_proxy`).
     ///
-    /// `general.network.proxy.url`
-    pub general_network_proxy_url: Option<String>,
+    /// `general.network.proxy`
+    pub general_network_proxy: Option<String>,
 
     /// Duration of the images cache in seconds. If `0` is set then no cache is
     /// used. Default is `28800` (8 hours).
@@ -79,11 +80,6 @@ pub struct Config {
     /// `cache.packages_allow_lists.duration`
     pub cache_packages_allow_lists_duration: Duration,
 
-    /// Proxy mode: `http`, `https` or `all`.
-    ///
-    /// `general.network.proxy.mode`
-    pub general_network_proxy_mode: Option<String>,
-
     /// URLs to the modules allow lists files.
     ///
     /// `packages.allow_lists`
@@ -94,6 +90,11 @@ pub struct Config {
     /// `packages.resources.path`
     pub packages_resources_path: PathBuf,
 
+    /// Remove resources that are not used by any game package.
+    ///
+    /// `packages.resources.collect_garbage`
+    pub packages_resources_collect_garbage: bool,
+
     /// Path to the folder where modules-specific files should be stored.
     ///
     /// These will be kept privately for each module, so they can be used as
@@ -101,6 +102,11 @@ pub struct Config {
     ///
     /// `packages.modules.path`
     pub packages_modules_path: PathBuf,
+
+    /// Remove modules directories if the module is not used by any package.
+    ///
+    /// `packages.modules.collect_garbage`
+    pub packages_modules_collect_garbage: bool,
 
     /// Path to the folder where persistent packages files should be stored.
     ///
@@ -118,6 +124,11 @@ pub struct Config {
     ///
     /// `packages.temporary.path`
     pub packages_temporary_path: PathBuf,
+
+    /// Clear temporary directory on launcher startup.
+    ///
+    /// `packages.temporary.collect_garbage`
+    pub packages_temporary_collect_garbage: bool,
 
     /// Maximal amount of memory in bytes allowed to be consumed by packages
     /// runtime (lua engine). If `0` is set then no limit is applied. Default is
@@ -168,8 +179,7 @@ impl Default for Config {
         Self {
             general_language: None,
             general_network_timeout: Duration::from_secs(5),
-            general_network_proxy_url: None,
-            general_network_proxy_mode: None,
+            general_network_proxy: None,
 
             cache_images_duration: Duration::from_hours(8),
             cache_game_registries_duration: Duration::from_hours(16),
@@ -182,9 +192,15 @@ impl Default for Config {
             ],
 
             packages_resources_path: DATA_FOLDER.join("packages").join("resources"),
+            packages_resources_collect_garbage: true,
+
             packages_modules_path: DATA_FOLDER.join("packages").join("modules"),
+            packages_modules_collect_garbage: true,
+
             packages_persistent_path: DATA_FOLDER.join("packages").join("persistent"),
+
             packages_temporary_path: DATA_FOLDER.join("packages").join("temporary"),
+            packages_temporary_collect_garbage: true,
 
             runtime_memory_limit: 1024 * 1024 * 1024,
 
@@ -210,10 +226,7 @@ impl Config {
 
             [general.network]
             timeout = (self.general_network_timeout.as_millis() as u64)
-
-            [general.network.proxy]
-            url = (self.general_network_proxy_url.as_deref().unwrap_or("system"))
-            mode = (self.general_network_proxy_mode.as_deref().unwrap_or("system"))
+            proxy = (self.general_network_proxy.as_deref().unwrap_or("system"))
 
             [cache.images]
             duration = (self.cache_images_duration.as_secs())
@@ -235,15 +248,18 @@ impl Config {
 
             [packages.resources]
             path = (self.packages_resources_path.to_string_lossy())
+            collect_garbage = (self.packages_resources_collect_garbage)
 
             [packages.modules]
             path = (self.packages_modules_path.to_string_lossy())
+            collect_garbage = (self.packages_modules_collect_garbage)
 
             [packages.persistent]
             path = (self.packages_persistent_path.to_string_lossy())
 
             [packages.temporary]
             path = (self.packages_temporary_path.to_string_lossy())
+            collect_garbage = (self.packages_temporary_collect_garbage)
 
             [runtime]
             memory_limit = (self.runtime_memory_limit)
@@ -286,23 +302,23 @@ impl Config {
                     };
                 }
 
-                // `general.network.proxy.*`
+                // `general.network.proxy`
                 if let Some(proxy) = network.get("proxy") {
-                    // `general.network.proxy.url`
-                    if let Some(url) = proxy.get("url").and_then(Toml::as_str) {
-                        config.general_network_proxy_url = if url == "system" {
+                    // New syntax (`general.network.proxy`).
+                    if let Some(url) = proxy.as_str() {
+                        config.general_network_proxy = if url == "system" {
                             None
                         } else {
                             Some(url.to_string())
                         };
                     }
 
-                    // `general.network.proxy.mode`
-                    if let Some(mode) = proxy.get("mode").and_then(Toml::as_str) {
-                        config.general_network_proxy_mode = if mode == "system" {
+                    // Old syntax (`general.network.proxy.url`).
+                    if let Some(url) = proxy.get("url").and_then(Toml::as_str) {
+                        config.general_network_proxy = if url == "system" {
                             None
                         } else {
-                            Some(mode.to_string())
+                            Some(url.to_string())
                         };
                     }
                 }
@@ -368,6 +384,11 @@ impl Config {
                 if let Some(path) = resources.get("path").and_then(Toml::as_str) {
                     config.packages_resources_path = PathBuf::from(path);
                 }
+
+                // `packages.resources.collect_garbage`
+                if let Some(value) = resources.get("collect_garbage").and_then(Toml::as_bool) {
+                    config.packages_resources_collect_garbage = value;
+                }
             }
 
             // `packages.modules.*`
@@ -375,6 +396,11 @@ impl Config {
                 // `packages.modules.path`
                 if let Some(path) = modules.get("path").and_then(Toml::as_str) {
                     config.packages_modules_path = PathBuf::from(path);
+                }
+
+                // `packages.modules.collect_garbage`
+                if let Some(value) = modules.get("collect_garbage").and_then(Toml::as_bool) {
+                    config.packages_modules_collect_garbage = value;
                 }
             }
 
@@ -391,6 +417,11 @@ impl Config {
                 // `packages.temporary.path`
                 if let Some(path) = temporary.get("path").and_then(Toml::as_str) {
                     config.packages_temporary_path = PathBuf::from(path);
+                }
+
+                // `packages.temporary.collect_garbage`
+                if let Some(value) = temporary.get("collect_garbage").and_then(Toml::as_bool) {
+                    config.packages_temporary_collect_garbage = value;
                 }
             }
         }
@@ -473,19 +504,11 @@ impl Config {
     /// network settings.
     pub fn client_builder(&self) -> anyhow::Result<reqwest::ClientBuilder> {
         let mut builder = reqwest::ClientBuilder::new()
-            .user_agent(format!("anime-games-launcher/{}", crate::consts::APP_VERSION))
+            .user_agent(format!("anime-games-launcher/v{}", crate::consts::APP_VERSION))
             .connect_timeout(self.general_network_timeout);
 
-        if let Some(proxy_url) = &self.general_network_proxy_url {
-            let proxy = match self.general_network_proxy_mode.as_deref() {
-                Some("http")  => reqwest::Proxy::http(proxy_url)?,
-                Some("https") => reqwest::Proxy::https(proxy_url)?,
-                Some("all")   => reqwest::Proxy::all(proxy_url)?,
-
-                _ => reqwest::Proxy::all(proxy_url)?
-            };
-
-            builder = builder.proxy(proxy);
+        if let Some(proxy_url) = &self.general_network_proxy {
+            builder = builder.proxy(reqwest::Proxy::all(proxy_url)?);
         }
 
         Ok(builder)
@@ -500,7 +523,7 @@ pub fn startup() -> &'static Config {
 
 /// Read configuration from the file.
 pub async fn get() -> Config {
-    agl_core::tasks::fs::read(CONFIG_FILE.as_path()).await.ok()
+    tasks::fs::read(CONFIG_FILE.as_path()).await.ok()
         .and_then(|config| toml::from_slice::<TomlTable>(&config).ok())
         .map(|config| Config::from_toml(&config))
         .unwrap_or_default()
@@ -508,7 +531,7 @@ pub async fn get() -> Config {
 
 /// Update configuration file.
 pub async fn set(config: &Config) -> anyhow::Result<()> {
-    agl_core::tasks::fs::write(
+    tasks::fs::write(
         CONFIG_FILE.as_path(),
         toml::to_string_pretty(&config.to_toml())?
     ).await?;

--- a/crates/anime-games-launcher/src/consts.rs
+++ b/crates/anime-games-launcher/src/consts.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // anime-games-launcher
-// Copyright (C) 2025  Nikita Podvirnyi <krypt0nn@vk.com>
+// Copyright (C) 2025 - 2026  Nikita Podvirnyi <krypt0nn@vk.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -36,9 +36,11 @@ lazy_static::lazy_static! {
     /// Path to the data folder.
     ///
     /// Default is `$XDG_DATA_HOME/anime-games-launcher`.
-    /// Can be overriden by `LAUNCHER_DATA_FOLDER` variable.
-    pub static ref DATA_FOLDER: PathBuf = {
-        if let Ok(path) = std::env::var("LAUNCHER_DATA_FOLDER") {
+    /// Can be overriden by `LAUNCHER_DATA_DIR` variable.
+    pub static ref DATA_DIR: PathBuf = {
+        if let Ok(path) = std::env::var("LAUNCHER_DATA_DIR")
+            .or_else(|_| std::env::var("LAUNCHER_DATA_FOLDER"))
+        {
             return PathBuf::from(path);
         }
 
@@ -70,9 +72,11 @@ lazy_static::lazy_static! {
     /// Path to the config folder.
     ///
     /// Default is `$XDG_CONFIG_HOME/anime-games-launcher`.
-    /// Can be overriden by `LAUNCHER_CONFIG_FOLDER` variable.
-    pub static ref CONFIG_FOLDER: PathBuf = {
-        if let Ok(path) = std::env::var("LAUNCHER_CONFIG_FOLDER") {
+    /// Can be overriden by `LAUNCHER_CONFIG_DIR` variable.
+    pub static ref CONFIG_DIR: PathBuf = {
+        if let Ok(path) = std::env::var("LAUNCHER_CONFIG_DIR")
+            .or_else(|_| std::env::var("LAUNCHER_CONFIG_FOLDER"))
+        {
             return PathBuf::from(path);
         }
 
@@ -104,9 +108,11 @@ lazy_static::lazy_static! {
     /// Path to the cache folder.
     ///
     /// Default is `$XDG_CACHE_HOME/anime-games-launcher`.
-    /// Can be overriden by `LAUNCHER_CACHE_FOLDER` variable.
-    pub static ref CACHE_FOLDER: PathBuf = {
-        if let Ok(path) = std::env::var("LAUNCHER_CACHE_FOLDER") {
+    /// Can be overriden by `LAUNCHER_CACHE_DIR` variable.
+    pub static ref CACHE_DIR: PathBuf = {
+        if let Ok(path) = std::env::var("LAUNCHER_CACHE_DIR")
+            .or_else(|_| std::env::var("LAUNCHER_CACHE_FOLDER"))
+        {
             return PathBuf::from(path);
         }
 
@@ -138,15 +144,15 @@ lazy_static::lazy_static! {
     /// Path to the config file.
     ///
     /// Default is `CONFIG_FOLDER/config.toml`.
-    pub static ref CONFIG_FILE: PathBuf = CONFIG_FOLDER.join("config.toml");
+    pub static ref CONFIG_FILE: PathBuf = CONFIG_DIR.join("config.toml");
 
     /// Path to the debug log file.
     ///
     /// Default is `DATA_FOLDER/debug.log`.
-    pub static ref DEBUG_FILE: PathBuf = DATA_FOLDER.join("debug.log");
+    pub static ref DEBUG_FILE: PathBuf = DATA_DIR.join("debug.log");
 
     /// Path to the trace log file.
     ///
     /// Default is `DATA_FOLDER/trace.log`.
-    pub static ref TRACE_FILE: PathBuf = DATA_FOLDER.join("trace.log");
+    pub static ref TRACE_FILE: PathBuf = DATA_DIR.join("trace.log");
 }

--- a/crates/anime-games-launcher/src/games.rs
+++ b/crates/anime-games-launcher/src/games.rs
@@ -108,7 +108,7 @@ impl GameLock {
         storage: &Storage
     ) -> anyhow::Result<Self> {
         // Prepare files downloader.
-        let config = config::get();
+        let config = config::get().await;
 
         let client = config.client_builder()?
             .build()?;

--- a/crates/anime-games-launcher/src/games.rs
+++ b/crates/anime-games-launcher/src/games.rs
@@ -120,12 +120,10 @@ impl GameLock {
 
         let manifest_path = cache::get_path(&manifest_url);
 
-        let is_expired = cache::is_expired(
+        if cache::is_expired(
             &manifest_path,
             config.cache_game_manifests_duration
-        )?;
-
-        if is_expired {
+        ).await? {
             let task = downloader.download_with_options(
                 &manifest_url,
                 &manifest_path,

--- a/crates/anime-games-launcher/src/ui/components/game_library_details.rs
+++ b/crates/anime-games-launcher/src/ui/components/game_library_details.rs
@@ -198,7 +198,7 @@ impl SimpleAsyncComponent for GameLibraryDetails {
                                     hint.as_ref()
                                         .map(|hint| {
                                             // FIXME: IO-heavy thing (there's around 6 update calls each time)
-                                            let config = config::get();
+                                            let config = agl_core::tasks::block_on(config::get());
 
                                             match config.language() {
                                                 Ok(lang) => hint.translate(&lang),
@@ -238,7 +238,7 @@ impl SimpleAsyncComponent for GameLibraryDetails {
                                 set_label?: model.game_actions_pipeline.as_ref()
                                     .map(|pipeline| {
                                         // FIXME: IO-heavy thing (there's around 6 update calls each time)
-                                        let config = config::get();
+                                        let config = agl_core::tasks::block_on(config::get());
 
                                         match config.language() {
                                             Ok(lang) => pipeline.title().translate(&lang),
@@ -251,7 +251,7 @@ impl SimpleAsyncComponent for GameLibraryDetails {
                                     .and_then(|pipeline| pipeline.description())
                                     .map(|description| {
                                         // FIXME: IO-heavy thing (there's around 6 update calls each time)
-                                        let config = config::get();
+                                        let config = agl_core::tasks::block_on(config::get());
 
                                         match config.language() {
                                             Ok(lang) => description.translate(&lang),
@@ -397,7 +397,7 @@ impl SimpleAsyncComponent for GameLibraryDetails {
 
                 self.background.emit(LazyPictureComponentMsg::SetImage(Some(background_image)));
 
-                let config = config::get();
+                let config = config::get().await;
 
                 let lang = config.language().ok();
 
@@ -487,7 +487,7 @@ impl SimpleAsyncComponent for GameLibraryDetails {
 
                             guards.clear();
 
-                            let config = config::get();
+                            let config = config::get().await;
 
                             let lang = config.language().ok();
 

--- a/crates/anime-games-launcher/src/ui/components/game_store_details.rs
+++ b/crates/anime-games-launcher/src/ui/components/game_store_details.rs
@@ -338,7 +338,7 @@ impl SimpleAsyncComponent for GameStoreDetails {
                 manifest_url,
                 manifest
             } => {
-                let config = config::get();
+                let config = config::get().await;
                 let lang = config.language().ok();
 
                 let title = match &lang {
@@ -423,7 +423,7 @@ impl SimpleAsyncComponent for GameStoreDetails {
             GameStoreDetailsInput::SetGameStatus(status) => self.status = status,
 
             GameStoreDetailsInput::UpdateGameStatus => {
-                let config = config::get();
+                let config = config::get().await;
 
                 let path = config.games_path.join(games::get_name(&self.manifest_url));
 
@@ -514,7 +514,7 @@ impl SimpleAsyncComponent for GameStoreDetails {
 
                 self.status = GameStatus::Adding;
 
-                let config = config::get();
+                let config = config::get().await;
 
                 let storage = match Storage::open(config.packages_resources_path) {
                     Ok(storage) => storage,
@@ -536,7 +536,7 @@ impl SimpleAsyncComponent for GameStoreDetails {
                             Ok(lock) => {
                                 sender.input(GameStoreDetailsInput::SetGameStatus(GameStatus::Added));
 
-                                let config = config::get();
+                                let config = config::get().await;
 
                                 let path = config.games_path.join(games::get_name(&lock.url));
 

--- a/crates/anime-games-launcher/src/ui/components/lazy_picture.rs
+++ b/crates/anime-games-launcher/src/ui/components/lazy_picture.rs
@@ -148,10 +148,10 @@ impl SimpleAsyncComponent for LazyPictureComponent {
                 Some(ImagePath::LazyLoad { url, .. }) => {
                     let cache_path = cache::get_path(url);
 
-                    let is_expired = cache::is_expired(
+                    let is_expired = agl_core::tasks::block_on(cache::is_expired(
                         &cache_path,
                         config::startup().cache_images_duration
-                    ).unwrap_or(true);
+                    )).unwrap_or(true);
 
                     if is_expired {
                         let downloader = Downloader::default();

--- a/crates/anime-games-launcher/src/ui/windows/game_actions_pipeline.rs
+++ b/crates/anime-games-launcher/src/ui/windows/game_actions_pipeline.rs
@@ -145,7 +145,8 @@ impl SimpleAsyncComponent for GameActionsPipelineWindow {
                 game_title,
                 actions_pipeline
             } => {
-                let lang = config::get().language().ok();
+                let lang = config::get().await
+                    .language().ok();
 
                 let title = match &lang {
                     Some(lang) => actions_pipeline.title().translate(lang),

--- a/crates/anime-games-launcher/src/ui/windows/game_apply_components.rs
+++ b/crates/anime-games-launcher/src/ui/windows/game_apply_components.rs
@@ -165,7 +165,8 @@ impl SimpleAsyncComponent for GameApplyComponentsWindow {
                 uninstall_components,
                 delete_game_package
             } => {
-                let lang = config::get().language().ok();
+                let lang = config::get().await
+                    .language().ok();
 
                 self.graph_group.emit(GraphProgressGroupMsg::ClearGraph);
                 self.graph_group.emit(GraphProgressGroupMsg::ClearProgressRows);

--- a/crates/anime-games-launcher/src/ui/windows/game_components.rs
+++ b/crates/anime-games-launcher/src/ui/windows/game_components.rs
@@ -207,7 +207,8 @@ impl SimpleAsyncComponent for GameComponentsWindow {
                 game_title,
                 layout
             } => {
-                let lang = config::get().language().ok();
+                let lang = config::get().await
+                    .language().ok();
 
                 let page = self.page.clone();
                 let footer_group = self.footer_group.clone();

--- a/crates/anime-games-launcher/src/ui/windows/game_settings.rs
+++ b/crates/anime-games-launcher/src/ui/windows/game_settings.rs
@@ -570,7 +570,8 @@ impl SimpleAsyncComponent for GameSettingsWindow {
                 variant,
                 layout
             } => {
-                let lang = config::get().language().ok();
+                let lang = config::get().await
+                    .language().ok();
 
                 let page = self.page.clone();
 

--- a/crates/anime-games-launcher/src/ui/windows/main_window/library_page.rs
+++ b/crates/anime-games-launcher/src/ui/windows/main_window/library_page.rs
@@ -290,7 +290,8 @@ impl SimpleAsyncComponent for LibraryPage {
                     "loading game package"
                 );
 
-                let lang = config::get().language();
+                let lang = config::get().await
+                    .language();
 
                 let title = match &lang {
                     Ok(lang) => package.manifest.game.title.translate(lang),
@@ -347,7 +348,7 @@ impl SimpleAsyncComponent for LibraryPage {
             }
 
             LibraryPageInput::DeleteGamePackage(name) => {
-                let config = config::get();
+                let config = config::get().await;
 
                 if let Some(game_info) = self.games.remove(&name) {
                     let lang = config.language();

--- a/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
+++ b/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
@@ -378,7 +378,7 @@ impl SimpleAsyncComponent for MainWindow {
         });
 
         fn translate(str: LocalizableString) -> String {
-            let config = agl_core::tasks::block_on(config::get());
+            let config = tasks::block_on(config::get());
 
             let str = match config.language() {
                 Ok(lang) => str.translate(&lang),
@@ -553,15 +553,15 @@ impl SimpleAsyncComponent for MainWindow {
                     .to_string()
             )));
 
-            agl_core::tasks::fs::create_dir_all(consts::DATA_FOLDER.as_path()).await?;
-            agl_core::tasks::fs::create_dir_all(consts::CONFIG_FOLDER.as_path()).await?;
-            agl_core::tasks::fs::create_dir_all(consts::CACHE_FOLDER.as_path()).await?;
+            tasks::fs::create_dir_all(consts::DATA_FOLDER.as_path()).await?;
+            tasks::fs::create_dir_all(consts::CONFIG_FOLDER.as_path()).await?;
+            tasks::fs::create_dir_all(consts::CACHE_FOLDER.as_path()).await?;
 
-            agl_core::tasks::fs::create_dir_all(&config::startup().packages_resources_path).await?;
-            agl_core::tasks::fs::create_dir_all(&config::startup().packages_modules_path).await?;
-            agl_core::tasks::fs::create_dir_all(&config::startup().packages_persistent_path).await?;
-            agl_core::tasks::fs::create_dir_all(&config::startup().packages_temporary_path).await?;
-            agl_core::tasks::fs::create_dir_all(&config::startup().games_path).await?;
+            tasks::fs::create_dir_all(&config::startup().packages_resources_path).await?;
+            tasks::fs::create_dir_all(&config::startup().packages_modules_path).await?;
+            tasks::fs::create_dir_all(&config::startup().packages_persistent_path).await?;
+            tasks::fs::create_dir_all(&config::startup().packages_temporary_path).await?;
+            tasks::fs::create_dir_all(&config::startup().games_path).await?;
 
             // Update the config file to create it if it didn't exist before.
             // Do it after creating all the folders, including the config one.
@@ -644,7 +644,7 @@ impl SimpleAsyncComponent for MainWindow {
             for path in paths {
                 tracing::trace!(?path, "reading packages allow list");
 
-                let allow_list = std::fs::read(path)?;
+                let allow_list = tasks::fs::read(path).await?;
                 let allow_list = serde_json::from_slice::<Json>(&allow_list)?;
 
                 let allow_list = AllowList::from_json(&allow_list)
@@ -708,7 +708,7 @@ impl SimpleAsyncComponent for MainWindow {
 
                 if let Err(err) = result {
                     // Remove half-downloaded/broken file.
-                    let _ = std::fs::remove_file(path);
+                    let _ = tasks::fs::remove_file(path).await;
 
                     return Err(err);
                 }
@@ -719,7 +719,7 @@ impl SimpleAsyncComponent for MainWindow {
             for path in paths {
                 tracing::trace!(?path, "reading game registry");
 
-                let registry = std::fs::read(path)?;
+                let registry = tasks::fs::read(path).await?;
                 let registry = serde_json::from_slice::<Json>(&registry)?;
 
                 let registry = GamesRegistryManifest::from_json(&registry)
@@ -791,7 +791,7 @@ impl SimpleAsyncComponent for MainWindow {
 
                 if let Err(err) = result {
                     // Remove half-downloaded/broken file.
-                    let _ = std::fs::remove_file(path);
+                    let _ = tasks::fs::remove_file(path).await;
 
                     return Err(err);
                 }
@@ -823,7 +823,7 @@ impl SimpleAsyncComponent for MainWindow {
                     "loading added game package lock"
                 );
 
-                let lock = std::fs::read(entry.path())?;
+                let lock = tasks::fs::read(entry.path()).await?;
                 let lock = serde_json::from_slice::<Json>(&lock)?;
 
                 let mut lock = GameLock::from_json(&lock)
@@ -862,10 +862,10 @@ impl SimpleAsyncComponent for MainWindow {
 
                     lock.scope = prev_scope;
 
-                    std::fs::write(
+                    tasks::fs::write(
                         entry.path(),
                         serde_json::to_vec_pretty(&lock.to_json())?
-                    )?;
+                    ).await?;
                 }
 
                 sender.input(MainWindowMsg::AddLibraryPageGame {
@@ -891,7 +891,7 @@ impl SimpleAsyncComponent for MainWindow {
             for (game_name, url, path, _is_featured) in paths {
                 tracing::trace!(?url, ?path, "reading game manifest");
 
-                let manifest = std::fs::read(path)?;
+                let manifest = tasks::fs::read(path).await?;
                 let manifest = serde_json::from_slice::<Json>(&manifest)?;
 
                 let manifest = GameManifest::from_json(&manifest)

--- a/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
+++ b/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
@@ -378,7 +378,7 @@ impl SimpleAsyncComponent for MainWindow {
         });
 
         fn translate(str: LocalizableString) -> String {
-            let config = config::get();
+            let config = agl_core::tasks::block_on(config::get());
 
             let str = match config.language() {
                 Ok(lang) => str.translate(&lang),
@@ -553,19 +553,19 @@ impl SimpleAsyncComponent for MainWindow {
                     .to_string()
             )));
 
-            std::fs::create_dir_all(consts::DATA_FOLDER.as_path())?;
-            std::fs::create_dir_all(consts::CONFIG_FOLDER.as_path())?;
-            std::fs::create_dir_all(consts::CACHE_FOLDER.as_path())?;
+            agl_core::tasks::fs::create_dir_all(consts::DATA_FOLDER.as_path()).await?;
+            agl_core::tasks::fs::create_dir_all(consts::CONFIG_FOLDER.as_path()).await?;
+            agl_core::tasks::fs::create_dir_all(consts::CACHE_FOLDER.as_path()).await?;
 
-            std::fs::create_dir_all(&config::startup().packages_resources_path)?;
-            std::fs::create_dir_all(&config::startup().packages_modules_path)?;
-            std::fs::create_dir_all(&config::startup().packages_persistent_path)?;
-            std::fs::create_dir_all(&config::startup().packages_temporary_path)?;
-            std::fs::create_dir_all(&config::startup().games_path)?;
+            agl_core::tasks::fs::create_dir_all(&config::startup().packages_resources_path).await?;
+            agl_core::tasks::fs::create_dir_all(&config::startup().packages_modules_path).await?;
+            agl_core::tasks::fs::create_dir_all(&config::startup().packages_persistent_path).await?;
+            agl_core::tasks::fs::create_dir_all(&config::startup().packages_temporary_path).await?;
+            agl_core::tasks::fs::create_dir_all(&config::startup().games_path).await?;
 
             // Update the config file to create it if it didn't exist before.
             // Do it after creating all the folders, including the config one.
-            config::set(config::startup())?;
+            config::set(config::startup()).await?;
 
             let config = config::startup();
             let lang = config.language();
@@ -982,7 +982,7 @@ impl SimpleAsyncComponent for MainWindow {
             }
 
             MainWindowMsg::AddLibraryPageGame { name, lock } => {
-                let config = config::get();
+                let config = config::get().await;
 
                 let lang = config.language();
 
@@ -1154,7 +1154,8 @@ impl SimpleAsyncComponent for MainWindow {
             }
 
             MainWindowMsg::ShowToast(options) => {
-                let lang = config::get().language();
+                let lang = config::get().await
+                    .language();
 
                 let title = match &options {
                     ToastOptions::Simple(title) => title,
@@ -1193,7 +1194,8 @@ impl SimpleAsyncComponent for MainWindow {
             }
 
             MainWindowMsg::ShowNotification(options) => {
-                let lang = config::get().language();
+                let lang = config::get().await
+                    .language();
 
                 let title = match &lang {
                     Ok(lang) => options.title.translate(lang),
@@ -1228,7 +1230,8 @@ impl SimpleAsyncComponent for MainWindow {
             }
 
             MainWindowMsg::ShowDialog(options) => {
-                let lang = config::get().language();
+                let lang = config::get().await
+                    .language();
 
                 let title = match &lang {
                     Ok(lang) => options.title.translate(lang),

--- a/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
+++ b/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
@@ -1377,7 +1377,9 @@ impl SimpleAsyncComponent for MainWindow {
             MainWindowMsg::LaunchGame { game_title, game_launch_info } => {
                 let mut command = &mut Command::new(&game_launch_info.binary);
 
-                if let Some(parent_folder) = game_launch_info.binary.parent() {
+                if let Some(parent_folder) = game_launch_info.binary.parent()
+                    && parent_folder.is_dir()
+                {
                     command = command.current_dir(parent_folder);
                 }
 

--- a/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
+++ b/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
@@ -17,8 +17,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::io::Read;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::path::Path;
 use std::process::{Command, Stdio};
 
 use adw::prelude::*;
@@ -32,6 +33,7 @@ use anyhow::Context;
 use agl_core::tasks;
 use agl_core::network::downloader::{Downloader, DownloadOptions};
 use agl_locale::string::LocalizableString;
+use agl_packages::hash::Hash;
 use agl_packages::storage::Storage;
 use agl_runtime::mlua::prelude::*;
 use agl_runtime::allow_list::AllowList;
@@ -362,7 +364,7 @@ impl SimpleAsyncComponent for MainWindow {
             TorrentServer::start(TorrentServerOptions {
                 default_folder: config.packages_temporary_path.clone(),
 
-                socks_proxy: match config.general_network_proxy_url.clone() {
+                socks_proxy: match config.general_network_proxy.clone() {
                     Some(proxy) if proxy.starts_with("socks") => Some(proxy),
                     _ => None
                 },
@@ -810,6 +812,8 @@ impl SimpleAsyncComponent for MainWindow {
             let storage = Storage::open(&config::startup().packages_resources_path)
                 .context("failed to open packages storage")?;
 
+            let mut resources = HashSet::new();
+
             for entry in config.games_path.read_dir()? {
                 let entry = entry?;
 
@@ -866,12 +870,81 @@ impl SimpleAsyncComponent for MainWindow {
                         entry.path(),
                         serde_json::to_vec_pretty(&lock.to_json())?
                     ).await?;
+
+                    resources.extend(lock.lock.resources.keys().copied());
                 }
 
                 sender.input(MainWindowMsg::AddLibraryPageGame {
                     name: game_name,
                     lock
                 });
+            }
+
+            // Collect garbage (unused resources, modules, temporary files).
+
+            tracing::debug!("collecting garbage");
+
+            sender.input(MainWindowMsg::SetLoadingStatus(Some(
+                i18n!("collecting_garbage")
+                    .unwrap_or("Collecting garbage")
+                    .to_string()
+            )));
+
+            async fn gc_packages_dir(
+                path: &Path,
+                resources: &HashSet<Hash>
+            ) -> std::io::Result<()> {
+                let mut entries = tasks::fs::read_dir(path).await?;
+
+                while let Some(entry) = entries.next_entry().await? {
+                    let path = entry.path();
+
+                    // Remove entry if its name is not a valid hash.
+                    let Some(hash) = Hash::from_base32(entry.file_name().to_string_lossy()) else {
+                        if path.is_dir() {
+                            tasks::fs::remove_dir_all(path).await?;
+                        } else {
+                            tasks::fs::remove_file(path).await?;
+                        }
+
+                        continue;
+                    };
+
+                    // Remove entry if none of loaded packages needs it.
+                    if !resources.contains(&hash) {
+                        if path.is_dir() {
+                            tasks::fs::remove_dir_all(path).await?;
+                        } else {
+                            tasks::fs::remove_file(path).await?;
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+
+            // Remove unused resources.
+            if config.packages_resources_collect_garbage {
+                gc_packages_dir(
+                    &config.packages_resources_path,
+                    &resources
+                ).await?;
+            }
+
+            // Remove unused modules directories.
+            if config.packages_modules_collect_garbage {
+                gc_packages_dir(
+                    &config.packages_modules_path,
+                    &resources
+                ).await?;
+            }
+
+            // Re-create temporary directory.
+            if config.packages_temporary_collect_garbage
+                && config.packages_temporary_path.is_dir()
+            {
+                tasks::fs::remove_dir_all(&config.packages_temporary_path).await?;
+                tasks::fs::create_dir_all(&config.packages_temporary_path).await?;
             }
 
             // Add store page games.

--- a/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
+++ b/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
@@ -1377,6 +1377,10 @@ impl SimpleAsyncComponent for MainWindow {
             MainWindowMsg::LaunchGame { game_title, game_launch_info } => {
                 let mut command = &mut Command::new(&game_launch_info.binary);
 
+                if let Some(parent_folder) = game_launch_info.binary.parent() {
+                    command = command.current_dir(parent_folder);
+                }
+
                 if let Some(args) = &game_launch_info.args {
                     command = command.args(args);
                 }

--- a/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
+++ b/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
@@ -555,9 +555,9 @@ impl SimpleAsyncComponent for MainWindow {
                     .to_string()
             )));
 
-            tasks::fs::create_dir_all(consts::DATA_FOLDER.as_path()).await?;
-            tasks::fs::create_dir_all(consts::CONFIG_FOLDER.as_path()).await?;
-            tasks::fs::create_dir_all(consts::CACHE_FOLDER.as_path()).await?;
+            tasks::fs::create_dir_all(consts::DATA_DIR.as_path()).await?;
+            tasks::fs::create_dir_all(consts::CONFIG_DIR.as_path()).await?;
+            tasks::fs::create_dir_all(consts::CACHE_DIR.as_path()).await?;
 
             tasks::fs::create_dir_all(&config::startup().packages_resources_path).await?;
             tasks::fs::create_dir_all(&config::startup().packages_modules_path).await?;
@@ -598,9 +598,13 @@ impl SimpleAsyncComponent for MainWindow {
             let mut tasks = Vec::with_capacity(config.packages_allow_lists.len());
             let mut paths = Vec::with_capacity(tasks.capacity());
 
+            let mut cache_hits = HashSet::new();
+
             // Either fetch package allow list or use cached one.
             for url in &config.packages_allow_lists {
                 let cache_path = cache::get_path(url);
+
+                cache_hits.insert(cache_path.clone());
 
                 tracing::trace!(?url, ?cache_path, "fetching packages allow list");
 
@@ -637,7 +641,7 @@ impl SimpleAsyncComponent for MainWindow {
 
                 if let Err(err) = result {
                     // Remove half-downloaded/broken file.
-                    let _ = std::fs::remove_file(path);
+                    let _ = tasks::fs::remove_file(path).await;
 
                     return Err(err);
                 }
@@ -674,6 +678,8 @@ impl SimpleAsyncComponent for MainWindow {
             // Either fetch game registry manifest or use cached one.
             for url in &config.games_registries {
                 let cache_path = cache::get_path(url);
+
+                cache_hits.insert(cache_path.clone());
 
                 tracing::trace!(?url, ?cache_path, "fetching game registry");
 
@@ -756,6 +762,8 @@ impl SimpleAsyncComponent for MainWindow {
             for (url, is_featured) in games_manifests {
                 let cache_path = cache::get_path(&url);
 
+                cache_hits.insert(cache_path.clone());
+
                 tracing::trace!(?url, ?cache_path, "fetching game manifest");
 
                 // If cache for this game manifest is expired - request the
@@ -796,6 +804,43 @@ impl SimpleAsyncComponent for MainWindow {
                     let _ = tasks::fs::remove_file(path).await;
 
                     return Err(err);
+                }
+            }
+
+            // Clear cache.
+
+            tracing::debug!("clear cache");
+
+            sender.input(MainWindowMsg::SetLoadingStatus(Some(
+                i18n!("clearing_cache")
+                    .unwrap_or("Clearing cache")
+                    .to_string()
+            )));
+
+            let mut entries = tasks::fs::read_dir(consts::CACHE_DIR.as_path()).await?;
+
+            while let Some(entry) = entries.next_entry().await? {
+                let path = entry.path();
+
+                if cache_hits.contains(&path) {
+                    continue;
+                }
+
+                let metadata = entry.metadata().await?;
+
+                if let Ok(timestamp) = metadata.modified()
+                    .or_else(|_| metadata.created())
+                    && timestamp.elapsed()
+                        .map(|elapsed| elapsed > config.cache_collect_garbage_after)
+                        .unwrap_or(true)
+                {
+                    tracing::trace!(?path, "remove expired cache entry");
+
+                    if metadata.is_dir() {
+                        tasks::fs::remove_dir_all(path).await?;
+                    } else {
+                        tasks::fs::remove_file(path).await?;
+                    }
                 }
             }
 
@@ -901,6 +946,8 @@ impl SimpleAsyncComponent for MainWindow {
 
                     // Remove entry if its name is not a valid hash.
                     let Some(hash) = Hash::from_base32(entry.file_name().to_string_lossy()) else {
+                        tracing::trace!(?path, "remove resource with invalid hash format");
+
                         if path.is_dir() {
                             tasks::fs::remove_dir_all(path).await?;
                         } else {
@@ -912,6 +959,8 @@ impl SimpleAsyncComponent for MainWindow {
 
                     // Remove entry if none of loaded packages needs it.
                     if !resources.contains(&hash) {
+                        tracing::trace!(?path, "remove unused resource");
+
                         if path.is_dir() {
                             tasks::fs::remove_dir_all(path).await?;
                         } else {

--- a/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
+++ b/crates/anime-games-launcher/src/ui/windows/main_window/mod.rs
@@ -604,12 +604,10 @@ impl SimpleAsyncComponent for MainWindow {
 
                 // If cache for this allow list is expired - request the list
                 // again.
-                let is_expired = cache::is_expired(
+                if cache::is_expired(
                     &cache_path,
                     config.cache_packages_allow_lists_duration
-                )?;
-
-                if is_expired {
+                ).await? {
                     tracing::trace!(?url, ?cache_path, "packages allow list cache is expired");
 
                     let task = downloader.download_with_options(
@@ -679,12 +677,10 @@ impl SimpleAsyncComponent for MainWindow {
 
                 // If cache for this registry is expired - request the registry
                 // value again.
-                let is_expired = cache::is_expired(
+                if cache::is_expired(
                     &cache_path,
                     config.cache_game_registries_duration
-                )?;
-
-                if is_expired {
+                ).await? {
                     tracing::trace!(?url, ?cache_path, "game registry cache is expired");
 
                     let task = downloader.download_with_options(
@@ -762,12 +758,10 @@ impl SimpleAsyncComponent for MainWindow {
 
                 // If cache for this game manifest is expired - request the
                 // manifest again.
-                let is_expired = cache::is_expired(
+                if cache::is_expired(
                     &cache_path,
                     config.cache_game_manifests_duration
-                )?;
-
-                if is_expired {
+                ).await? {
                     tracing::trace!(?url, ?cache_path, "game manifest cache is expired");
 
                     let task = downloader.download_with_options(
@@ -845,12 +839,10 @@ impl SimpleAsyncComponent for MainWindow {
                         .unwrap_or_else(|| format!("Loading {title} game package"))
                 )));
 
-                let is_expired = cache::is_expired(
-                    entry.path(),
+                if cache::is_expired(
+                    &entry.path(),
                     config.cache_game_packages_duration
-                )?;
-
-                if is_expired {
+                ).await? {
                     tracing::trace!(
                         path = ?entry.path(),
                         ?game_name,

--- a/crates/anime-games-launcher/src/ui/windows/main_window/store_page.rs
+++ b/crates/anime-games-launcher/src/ui/windows/main_window/store_page.rs
@@ -226,7 +226,7 @@ impl SimpleAsyncComponent for StorePage {
                     "adding store page game"
                 );
 
-                let config = config::get();
+                let config = config::get().await;
                 let lang = config.language().ok();
 
                 let title = match &lang {

--- a/crates/anirun/src/main.rs
+++ b/crates/anirun/src/main.rs
@@ -376,7 +376,7 @@ fn build_client(
     timeout: Option<Duration>
 ) -> anyhow::Result<reqwest::Client> {
     let mut client = reqwest::ClientBuilder::new()
-        .user_agent(user_agent.unwrap_or_else(|| format!("anirun/{APP_VERSION}")));
+        .user_agent(user_agent.unwrap_or_else(|| format!("anirun/v{APP_VERSION}")));
 
     if let Some(proxy) = &proxy {
         let proxy = reqwest::Proxy::all(proxy)
@@ -673,7 +673,7 @@ fn main() -> anyhow::Result<()> {
                 for (package_hash, package) in lock.packages.iter() {
                     for (resource_name, resource) in package.outputs.iter() {
                         if resource.format == ResourceFormat::File
-                            && resource.url.contains(".lua")
+                            && (resource.url.ends_with(".lua") || resource.url.ends_with(".luau"))
                             && let Some(output) = runtime.get_value::<LuaTable>(format!("{}#module", resource.hash))?
                         {
                             let output = output.get::<LuaValue>("value")?;

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778672786,
-        "narHash": "sha256-Blg88K1jwG+P0Mr27+rKMFCufdrWkV3wWh9AdYtz0FQ=",
+        "lastModified": 1782821651,
+        "narHash": "sha256-D5jO0ME1lA9bDHnd5kVawBwItG/N4oZr3FlXmMzLec8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eef00dfd8a712b34af845f9350bac681b1228bd1",
+        "rev": "e52c192be9d7b2c4bd4aed326c8731b35f8bb75c",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778728594,
-        "narHash": "sha256-+gIOsOzqWNfn+ThCXBQGcLHVEnaGQW59XjghE9JUIYk=",
+        "lastModified": 1782875958,
+        "narHash": "sha256-5eqDcnBjb1424HRQdnhuhNOBZguq1Z2tqSa2OMF/m2c=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "83a17ebffcfacb17b49e1b5e9dc15eed07936648",
+        "rev": "13139aefa973f3d96c60c0fbab801de058ae25ca",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,8 @@
                         # adwaita-1-demo
                         libadwaita.devdoc
                         icon-library
+
+                        python3
                     ];
 
                     buildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -12,23 +12,17 @@
     };
 
     outputs = { self, nixpkgs, flake-utils, rust-overlay }:
-        flake-utils.lib.eachDefaultSystem (system:
-            let
-                pkgs = import nixpkgs {
-                    inherit system;
-
-                    overlays = [ rust-overlay.overlays.default ];
-                };
-
-                config = pkgs.lib.importTOML ./crates/anime-games-launcher/Cargo.toml;
-
-            in {
-                packages.default = pkgs.rustPlatform.buildRustPackage {
+        let
+            buildLauncher = pkgs:
+                let
+                    config = pkgs.lib.importTOML ./crates/anime-games-launcher/Cargo.toml;
+                in pkgs.rustPlatform.buildRustPackage {
                     pname = config.package.name;
                     version = config.package.version;
 
                     src = ./.;
                     cargoLock.lockFile = ./Cargo.lock;
+                    cargoBuildFlags = [ "--package=anime-games-launcher" ];
 
                     doCheck = false;
 
@@ -49,8 +43,6 @@
                     };
 
                     nativeBuildInputs = with pkgs; [
-                        rust-bin.stable.latest.minimal
-
                         gcc
                         cmake
                         glib
@@ -61,46 +53,153 @@
                         wrapGAppsHook4
                         libnotify
                         dbus
+                        makeWrapper
                     ];
 
                     buildInputs = with pkgs; [
                         libadwaita
                         gdk-pixbuf
                     ];
+
+                    postInstall = ''
+                        install -Dm644 crates/anime-games-launcher/assets/anime-games-launcher.desktop \
+                            $out/share/applications/anime-games-launcher.desktop
+
+                        install -Dm644 crates/anime-games-launcher/assets/images/icon.png \
+                            $out/share/icons/hicolor/scalable/apps/moe.launcher.anime-games-launcher.png
+                    '';
+
+                    preFixup = ''
+                        gappsWrapperArgs+=(
+                            --prefix PATH : "${pkgs.lib.makeBinPath [ pkgs.unzip pkgs.p7zip ]}"
+                        )
+                    '';
                 };
 
-                devShells.default = pkgs.mkShell {
+            buildAnirun = pkgs:
+                let
+                    config = pkgs.lib.importTOML ./crates/anirun/Cargo.toml;
+                in pkgs.rustPlatform.buildRustPackage {
+                    pname = config.package.name;
+                    version = config.package.version;
+
+                    src = ./.;
+                    cargoLock.lockFile = ./Cargo.lock;
+                    cargoBuildFlags = [ "--package=anirun" ];
+
+                    doCheck = false;
+
+                    meta = with pkgs.lib; {
+                        description = config.package.description;
+                        homepage = config.package.homepage;
+                        license = licenses.gpl3Plus;
+
+                        maintainers = [
+                            {
+                                name = "Nikita Podvirnyi";
+                                email = "krypt0nn@vk.com";
+                                matrix = "@krypt0nn:mozilla.org";
+                                github = "krypt0nn";
+                                githubId = 29639507;
+                            }
+                        ];
+                    };
+
                     nativeBuildInputs = with pkgs; [
-                        (rust-bin.stable.latest.default.override {
-                            extensions = [ "rust-src" ];
+                        gcc
+                        cmake
+                        glib
+                        pkg-config
+                        makeWrapper
+                    ];
+
+                    preFixup = ''
+                        wrapProgram $out/bin/anirun \
+                            --prefix PATH : "${pkgs.lib.makeBinPath [ pkgs.unzip pkgs.p7zip ]}"
+                    '';
+                };
+        in
+            (flake-utils.lib.eachDefaultSystem (system:
+                let
+                    pkgs = import nixpkgs {
+                        inherit system;
+
+                        overlays = [ rust-overlay.overlays.default ];
+                    };
+                in {
+                    packages = rec {
+                        default = anime-games-launcher;
+
+                        anime-games-launcher = buildLauncher pkgs;
+                        anirun = buildAnirun pkgs;
+                    };
+
+                    devShells.default = pkgs.mkShell {
+                        nativeBuildInputs = with pkgs; [
+                            (rust-bin.stable.latest.default.override {
+                                extensions = [ "rust-src" ];
+                            })
+
+                            gcc
+                            cmake
+                            glib
+                            pkg-config
+
+                            gtk4
+                            gobject-introspection
+                            wrapGAppsHook4
+                            libnotify
+                            dbus
+
+                            unzip
+                            p7zip
+
+                            # adwaita-1-demo
+                            libadwaita.devdoc
+                            icon-library
+
+                            python3
+                        ];
+
+                        buildInputs = with pkgs; [
+                            libadwaita
+                            gdk-pixbuf
+                        ];
+                    };
+                }
+            )) // {
+                nixosModules.anime-games-launcher = { config, lib, pkgs, ... }: let
+                    cfg = config.programs.anime-games-launcher;
+                in {
+                    options.programs.anime-games-launcher = {
+                        enable = lib.mkEnableOption "Enable Anime Games Launcher";
+
+                        package = lib.mkOption {
+                            type = lib.types.package;
+                            default = buildLauncher pkgs;
+                            description = "The anime-games-launcher package to use";
+                        };
+
+                        anirun = {
+                            enable = lib.mkEnableOption "Enable anime games launcher CLI tool for lua runtime evals";
+
+                            package = lib.mkOption {
+                                type = lib.types.package;
+                                default = buildAnirun pkgs;
+                                description = "The anirun package to use";
+                            };
+                        };
+                    };
+
+                    config = lib.mkMerge [
+                        (lib.mkIf cfg.enable {
+                            environment.systemPackages = [ cfg.package ];
                         })
 
-                        gcc
-                        cmake
-                        glib
-                        pkg-config
-
-                        gtk4
-                        gobject-introspection
-                        wrapGAppsHook4
-                        libnotify
-                        dbus
-
-                        git
-                        unzip
-                        p7zip
-
-                        # adwaita-1-demo
-                        libadwaita.devdoc
-                        icon-library
-
-                        python3
-                    ];
-
-                    buildInputs = with pkgs; [
-                        libadwaita
-                        gdk-pixbuf
+                        (lib.mkIf cfg.anirun.enable {
+                            environment.systemPackages = [ cfg.anirun.package ];
+                        })
                     ];
                 };
-            });
+            };
 }

--- a/locales.py
+++ b/locales.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError:
+        print("Error: Python 3.11+ (tomllib) or the 'tomli' package is required.")
+        sys.exit(1)
+
+LOCALES_DIR = Path("crates/anime-games-launcher/assets/locales")
+
+
+def load_all_locales():
+    """Load all .toml files from the locales directory into a dict keyed by filename stem."""
+    locales = {}
+    if not LOCALES_DIR.is_dir():
+        print(f"Error: locales directory not found at '{LOCALES_DIR}'")
+        sys.exit(1)
+    for toml_file in sorted(LOCALES_DIR.glob("*.toml")):
+        with open(toml_file, "rb") as f:
+            data = tomllib.load(f)
+        rel_path = f"./{toml_file}"
+        locales[toml_file.stem] = {"path": rel_path, "data": data}
+    return locales
+
+
+def format_toml_file(filepath):
+    """
+    Parses a TOML file preserving comments and blank lines, sorts the language
+    keys within each section based on priority and variants, and saves it.
+    Returns a tuple of (was_changed, num_keys).
+    """
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    lines = content.split('\n')
+
+    header_lines = []
+    sections = []
+    current_section = None
+    current_prefix = []
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped.startswith('[') and stripped.endswith(']'):
+            if current_section is not None:
+                current_section['suffix'] = current_prefix
+                sections.append(current_section)
+            else:
+                header_lines.extend(current_prefix)
+
+            current_prefix = []
+            current_section = {
+                'header': line,
+                'entries': [],
+                'suffix': []
+            }
+        elif current_section is not None:
+            if '=' in stripped and not stripped.startswith('#'):
+                lang = stripped.split('=', 1)[0].strip()
+                current_section['entries'].append({
+                    'prefix': current_prefix,
+                    'lang': lang,
+                    'line': line
+                })
+                current_prefix = []
+            else:
+                current_prefix.append(line)
+        else:
+            current_prefix.append(line)
+
+    if current_section is not None:
+        current_section['suffix'] = current_prefix
+        sections.append(current_section)
+    elif current_prefix:
+        header_lines.extend(current_prefix)
+
+    def sort_key(lang):
+        base = lang[:2]
+        priority = {
+            'en': 0,
+            'ru': 1,
+            'es': 2,
+            'pt': 3,
+            'fr': 4,
+            'de': 5
+        }.get(base, 6)
+        is_specific = 0 if lang == base else 1
+        return (priority, base, is_specific, lang)
+
+    output_lines = []
+    output_lines.extend(header_lines)
+
+    for section in sections:
+        output_lines.append(section['header'])
+
+        section['entries'].sort(key=lambda e: sort_key(e['lang']))
+
+        for entry in section['entries']:
+            output_lines.extend(entry['prefix'])
+            output_lines.append(entry['line'])
+
+        output_lines.extend(section['suffix'])
+
+    new_content = '\n'.join(output_lines)
+
+    if content.endswith('\n') and not new_content.endswith('\n'):
+        new_content += '\n'
+
+    changed = new_content != content
+    if changed:
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+
+    return changed, len(sections)
+
+
+def cmd_list():
+    locales = load_all_locales()
+    if not locales:
+        print("No locale files found.")
+        return
+
+    max_name_len = max(len(name) for name in locales) if locales else 0
+    for file_name, file_info in locales.items():
+        print(f"{file_name:<{max_name_len}}  ({file_info['path']})")
+
+
+def cmd_tree():
+    locales = load_all_locales()
+    if not locales:
+        print("No locale files found.")
+        return
+
+    for file_name, file_info in locales.items():
+        data = file_info["data"]
+        rel_path = file_info["path"]
+
+        sections = {k: v for k, v in data.items() if isinstance(v, dict)}
+        if not sections:
+            print(f"{file_name} ({rel_path})")
+            print()
+            continue
+
+        max_key_len = max(len(k) for k in sections)
+
+        all_langs = sorted(set(lang for trans in sections.values() for lang in trans))
+        lang_widths = {lang: len(lang) for lang in all_langs}
+
+        print(f"{file_name} ({rel_path})")
+        for key, translations in sections.items():
+            line = f"  {key:<{max_key_len}}  "
+
+            for lang in all_langs:
+                width = lang_widths[lang]
+                if lang in translations:
+                    line += f"{lang:<{width}} "
+                else:
+                    line += f"{' ' * width} "
+
+            print(line.rstrip())
+        print()
+
+
+def cmd_available(locale_key):
+    locales = load_all_locales()
+    found_any = False
+
+    for file_name, file_info in locales.items():
+        data = file_info["data"]
+        rel_path = file_info["path"]
+
+        sections = {k: v for k, v in data.items() if isinstance(v, dict)}
+        matching = {k: v for k, v in sections.items() if locale_key in v}
+
+        if matching:
+            found_any = True
+            print(f"{file_name} ({rel_path})")
+            max_key_len = max(len(k) for k in matching)
+            for key, translations in matching.items():
+                value = translations[locale_key]
+                print(f"  {key:<{max_key_len}}  {value}")
+            print()
+
+    if not found_any:
+        print(f"No translations found for locale '{locale_key}'.")
+
+
+def cmd_missing(locale_key=None):
+    locales = load_all_locales()
+    found_any = False
+
+    if locale_key:
+        for file_name, file_info in locales.items():
+            data = file_info["data"]
+            rel_path = file_info["path"]
+
+            sections = {k: v for k, v in data.items() if isinstance(v, dict)}
+            missing = {k: v for k, v in sections.items() if locale_key not in v}
+
+            if missing:
+                found_any = True
+                print(f"{file_name} ({rel_path})")
+                max_key_len = max(len(k) for k in missing)
+                for key, translations in missing.items():
+                    available = sorted(translations.keys())
+                    avail_str = ", ".join(available) if available else "none"
+                    print(f"  {key:<{max_key_len}}  missing  (has: {avail_str})")
+                print()
+
+        if not found_any:
+            print(f"No missing translations for locale '{locale_key}' — all keys have it!")
+
+    else:
+        all_global_langs = set()
+        for file_info in locales.values():
+            data = file_info["data"]
+            sections = {k: v for k, v in data.items() if isinstance(v, dict)}
+            for trans in sections.values():
+                all_global_langs.update(trans.keys())
+
+        all_global_langs = sorted(all_global_langs)
+
+        if not all_global_langs:
+            print("No languages found in any locale files.")
+            return
+
+        for file_name, file_info in locales.items():
+            data = file_info["data"]
+            rel_path = file_info["path"]
+
+            sections = {k: v for k, v in data.items() if isinstance(v, dict)}
+            if not sections:
+                continue
+
+            missing_in_file = {}
+            for key, translations in sections.items():
+                missing_langs = [lang for lang in all_global_langs if lang not in translations]
+                if missing_langs:
+                    missing_in_file[key] = missing_langs
+
+            if missing_in_file:
+                found_any = True
+                print(f"{file_name} ({rel_path})")
+                max_key_len = max(len(k) for k in missing_in_file)
+                for key, missing_langs in missing_in_file.items():
+                    missing_str = " ".join(missing_langs)
+                    print(f"  {key:<{max_key_len}}  {missing_str}")
+                print()
+
+        if not found_any:
+            print("No missing translations — all keys have translations for all available languages!")
+
+
+def cmd_format(files_to_format=None):
+    locales = load_all_locales()
+    if not locales:
+        print("No locale files found.")
+        return
+
+    if files_to_format:
+        valid_files = {}
+        for f in files_to_format:
+            if f in locales:
+                valid_files[f] = locales[f]
+            else:
+                print(f"Warning: File '{f}.toml' not found in {LOCALES_DIR}")
+
+        if not valid_files:
+            print("No valid files specified for formatting.")
+            return
+
+        files_to_process = valid_files
+    else:
+        files_to_process = locales
+
+    files_changed = 0
+    total_keys = 0
+
+    for file_name, file_info in files_to_process.items():
+        filepath = Path(file_info['path'].lstrip('./'))
+        changed, keys = format_toml_file(filepath)
+        total_keys += keys
+        if changed:
+            files_changed += 1
+            print(f"  Updated {file_info['path']}")
+
+    print(f"\nFormatted {len(files_to_process)} files ({files_changed} changed), containing {total_keys} translation keys.")
+
+
+def cmd_help():
+    print(
+        "Usage: locales.py <command> [arguments]\n"
+        "\n"
+        "Commands:\n"
+        "  list                  List all available locale files and their paths\n"
+        "  tree                  Show a tree of all locale files, keys, and available languages\n"
+        "  available <locale>    List keys that have a translation in the given language\n"
+        "  missing [locale]      With <locale>: list keys missing that specific language.\n"
+        "                        Without <locale>: list keys missing any available language.\n"
+        "  format [files...]     Format and sort locale files by language priority.\n"
+        "                        If no files provided, formats all files.\n"
+        "  help                  Show this help message\n"
+        "\n"
+        "Examples:\n"
+        "  python3 locales.py list\n"
+        "  python3 locales.py tree\n"
+        "  python3 locales.py available de\n"
+        "  python3 locales.py missing pt\n"
+        "  python3 locales.py missing\n"
+        "  python3 locales.py format interface errors\n"
+        "  python3 locales.py format"
+    )
+
+
+def main():
+    args = sys.argv[1:]
+
+    if len(args) == 0 or args[0] == "help":
+        cmd_help()
+    elif args[0] == "list":
+        cmd_list()
+    elif args[0] == "tree":
+        cmd_tree()
+    elif args[0] == "available":
+        if len(args) < 2:
+            print("Error: 'available' requires a locale key (e.g., 'en', 'de').")
+            sys.exit(1)
+        cmd_available(args[1])
+    elif args[0] == "missing":
+        if len(args) > 1:
+            cmd_missing(args[1])
+        else:
+            cmd_missing()
+    elif args[0] == "format":
+        cmd_format(args[1:])
+    else:
+        print(f"Unknown command: '{args[0]}'\n")
+        cmd_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Release v2.1.1

This is a minor release that brings a couple of non-breaking changes and new features.

More information about the changes is available in the documentation.

## Updated `enum` and `selector` settings entries

Previously, both `enum` and `selector` settings entries had `values` field accepting a key-value table (for example, `{ entry1 = "Entry 1", entry2 = "Entry 2" }`). The problem with this design is that it breaks the values order, and launcher interface was rendering these values in randomly. To combat this, I've made these values sorted by their title.

In this update, I introduced a new syntax for values: a list of name and title objects (for example, `{ { name = "entry1", title = "Entry 1" }, { name = "entry2", title = "Entry 2" } }`). Lists are indexed by numbers in ascending order and guaranteed to preserve their original order written in the code.

Both syntaxes are supported now. If old syntax detected, launcher will print warning message in logs. Values sorting is applied only to the old syntax values.

```
2026-07-01T18:14:20.636857Z  WARN agl_games::api::game_settings: using outdated enum settings entry values syntax
2026-07-01T18:14:20.637006Z  WARN agl_games::api::game_settings: using outdated enum settings entry values syntax
```

Before:

<img width="1438" height="322" alt="image" src="https://github.com/user-attachments/assets/ce3c8221-0cc9-499d-bd24-30e69afae1b9" />

After:

<img width="1437" height="321" alt="image" src="https://github.com/user-attachments/assets/ac23fec7-2603-40d9-aef5-20f02731ec0d" />

## `fs.metadata` API changes

The API output got `accessed_at` field, representing amount of seconds passed after the file was accessed for the last time. `created_at`, `modified_at` and `accessed_at` fields can also be set to `nil` now if the API failed to query appropriate information from the user's file system (e.g. if it's mounted with `noatime` attribute).

Example output of `dbg(fs.metadata("..."))`:

```lua
{
  accessed_at = 1780498234,
  created_at = 1780490365,
  length = 7513,
  modified_at = 1780865928,
  permissions = {
    read = false,
    write = false,
  },
  type = "file"
}
```

## `import` API

For a long time we had the [`import`](https://github.com/an-anime-team/game-integrations/tree/8692fcd6e7a18106762241df05ea8fb1105f0ad1/packages/import) library that used standard `load` function to provide a more user-friendly output of a package's input. Now this library becomes obsolete and the `import` function becomes standard for everyone. In addition to the library's `import` function, the new standard `import` function will support path-like dependencies. For example, if your input is a package with its own outputs - you can import specific output by using `package_name/output_name` syntax.

Using [lua-proton](https://github.com/an-anime-team/game-integrations/tree/8692fcd6e7a18106762241df05ea8fb1105f0ad1/packages/lua-proton) with standard `load` function:

```luau
local lua_proton = load("lua-proton").value.proton({ ... })
```

With `import`:

```luau
local lua_proton = import("lua-proton").proton({ ... })
```

With `import` and path-like syntax:

```luau
local lua_proton = import("lua-proton/proton")({ ... })
```

A simple polyfill without path-like syntax support would look like this:

```lua
if not import then
    -- polyfill: old agl-runtime versions don't have `import` function
    function import(name: string)
        local resource = load(name)

        if resource.format ~= "package" then
            return resource.value
        end

        local outputs = {}

        for name, value in pairs(resource.value) do
            outputs[name] = value.value
        end

        return outputs
    end
end
```

It's already presented in many official games integrations and packages.

## Garbage collection

The launcher finally received a packages, resources, and caches garbage collection. Now during startup it will scan a number of service directories, determine old or unused resources, and delete them. This behavior can be configured via new config file entries.

```
2026-07-01T18:13:13.469406Z TRACE anime_games_launcher::ui::windows::main_window: remove unused resource path="/home/observer/.local/share/anime-games-launcher/packages/resources/jkikoate2qcps"
2026-07-01T18:13:13.469769Z TRACE anime_games_launcher::ui::windows::main_window: remove unused resource path="/home/observer/.local/share/anime-games-launcher/packages/resources/v07d5drmlqgdo"
2026-07-01T18:13:13.470112Z TRACE anime_games_launcher::ui::windows::main_window: remove unused resource path="/home/observer/.local/share/anime-games-launcher/packages/resources/nan9n5iqutu8s"
```

## Game process working directory

Previously, spawned game process would inherit current working directory from the launcher. Now launcher will try to obtain parent directory of the game's binary and set it as the game's current working directory.